### PR TITLE
New feature: Cutoff time for applying inWords

### DIFF
--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -25,6 +25,7 @@
     settings: {
       refreshMillis: 60000,
       allowFuture: false,
+      cutoff: 0,
       strings: {
         prefixAgo: null,
         prefixFromNow: null,
@@ -111,8 +112,12 @@
 
   function refresh() {
     var data = prepareData(this);
+    var $s = $t.settings;
+
     if (!isNaN(data.datetime)) {
-      $(this).text(inWords(data.datetime));
+      if ( $s.cutoff == 0 || distance(data.datetime) < $s.cutoff) {
+        $(this).text(inWords(data.datetime));
+      }
     }
     return this;
   }

--- a/test/index.html
+++ b/test/index.html
@@ -73,6 +73,12 @@
     <p>Date only (default tooltip): <abbr id="defaultTooltip" class="timeago" title="2008-02-26"> </abbr>.</p>
     <p>Timestsamp (with millis): <abbr class="timeago" title="1978-12-18T17:17:00.021Z">(you shouldn't see this)</abbr>.</p>
 
+    <h2>Cutoff</h2>
+
+    <p>Date that is older than cutoff: <abbr class="timeago cutoff doCutoff" title="1978-12-18">(this should be displayed)</abbr></p>
+
+    <p>Date that is newer than cutoff: <abbr class="timeago loaded cutoff dontCutoff">(you shouldn't see this)</abbr></p>
+
     <h2>Errors</h2>
 
     <p>Bad (letters): <abbr class="bad timeago" title="bleh">(this should be displayed)</abbr>.</p>
@@ -212,8 +218,12 @@
 
       prepareDynamicDates();
 
-      $("abbr.timeago").timeago();
+      $("abbr.timeago").not("abbr.cutoff").timeago();
       $("time.timeago").timeago();
+
+      loadCutoffSetting();
+      $("abbr.cutoff").timeago();
+      unloadCutoffSetting();
 
       var tooltip = $("#testTooltip").data("timeago");
 
@@ -283,6 +293,20 @@
       test("should set timeago data object", function () {
         ok(tooltip, "data set");
         ok(tooltip.datetime, "datetime set");
+      });
+
+      module("Cutoff");
+
+      test("should not change dates older than cutoff setting", function () {
+        ok(testElements("abbr.doCutoff", function (element) {
+          return (element.html() === "(this should be displayed)");
+        }), "Cutoff setting working fine");
+      });
+
+      test("should change dates newer than cutoff setting", function () {
+        ok(testElements("abbr.dontCutoff", function (element) {
+          return (element.html() === "less than a minute ago");
+        }), "Cutoff setting working fine");
       });
 
       module("Tooltip");

--- a/test/test_helpers.js
+++ b/test/test_helpers.js
@@ -22,6 +22,14 @@ function unloadNumbers() {
   jQuery.timeago.settings.strings.numbers = [];
 }
 
+function loadCutoffSetting() {
+	jQuery.timeago.settings.cutoff = 7*24*60*60*1000;
+}
+
+function unloadCutoffSetting() {
+	jQuery.timeago.settings.cutoff = 0;
+}
+
 function loadPigLatin() {
   jQuery.timeago.settings.strings = {
     suffixAgo: "ago-hay",


### PR DESCRIPTION
I wanted to control when timeago applies inWords. Older dates should appear with their original representation, and newer dates, for instance newer than a week, should get the fuzzy timestamp.

This commit adds a setting, cutoff, that can be set to the number of milliseconds that marks the cutoff between using the original and the fuzzy date.

I've tried to use your coding style, and passing tests are included, even if this is the first time I've written Javascript unit tests. Hope you can use it!

-martin
