### PR TITLE
Allow timeago to be used with jquery-livequery

### DIFF
--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -24,6 +24,8 @@
     }
   };
   var $t = $.timeago;
+  var intervalId = null;
+  var elements = [];
 
   $.extend($.timeago, {
     settings: {
@@ -102,13 +104,19 @@
     }
   });
 
-  $.fn.timeago = function() {
+  $.fn.timeago = function(clear) {
     var self = this;
-    self.each(refresh);
+    self.each(function (i, element) {
+        if ($.inArray(element, elements) == -1)
+            elements.push(element);
+    });
+    $.each(elements, refresh);
 
     var $s = $t.settings;
     if ($s.refreshMillis > 0) {
-      setInterval(function() { self.each(refresh); }, $s.refreshMillis);
+      if (intervalId === null) {
+        intervalId = setInterval(function() { $.each(elements, refresh); }, $s.refreshMillis);
+      }
     }
     return self;
   };


### PR DESCRIPTION
livequery extends selectors to find elements "even after the page has been loaded and the DOM updated".

This patch extends timeago to be used in conjunction with livequery.

The changes are pretty simple but simply not very pretty. I'd be happy if this idea would go into timeago even in a different form.
