### PR TITLE
Added in support for displaying weeks instead of days.

### DIFF
--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -41,6 +41,8 @@
         hours: "about %d hours",
         day: "a day",
         days: "%d days",
+        week: "a week",
+        weeks: "%d weeks",
         month: "about a month",
         months: "%d months",
         year: "about a year",
@@ -78,7 +80,8 @@
         minutes < 90 && substitute($l.hour, 1) ||
         hours < 24 && substitute($l.hours, Math.round(hours)) ||
         hours < 48 && substitute($l.day, 1) ||
-        days < 30 && substitute($l.days, Math.floor(days)) ||
+        days < 14 && substitute($l.week, 1) ||
+        days < 30 && substitute($l.weeks, Math.floor(days / 7)) ||
         days < 60 && substitute($l.month, 1) ||
         days < 365 && substitute($l.months, Math.floor(days / 30)) ||
         years < 2 && substitute($l.year, 1) ||


### PR DESCRIPTION
If we're displaying something that occurred less than 30 days ago, instead of showing something like "26 days ago" jquery-timeago will now display "3 weeks ago".
