### PR TITLE
Improving l10n-ability by adding callbacks for numbers and formatter

### DIFF
--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -69,7 +69,7 @@
 
       function substitute(stringOrFunction, number) {
         var string = $.isFunction(stringOrFunction) ? stringOrFunction(number, distanceMillis) : stringOrFunction;
-        var value = $.isFunction($l.numbers) ? $l.numbers(number) : ($l.numbers[number] || number);
+        var value = $.isFunction($l.numbers) ? $l.numbers(number) : (($l.numbers && $l.numbers[number]) || number);
         return string.replace(/%d/i, value);
       }
 


### PR DESCRIPTION
Allowing `jQuery.timeago.settings.strings.numbers` to be a callback function and adding optional `jQuery.timeago.settings.strings.formatter` callback, which can be used as a general post processing callback instead of the default `$.trim([prefix, words, suffix].join(" "))`.

This allows 100% localized Japanese for example:

```
jQuery.timeago.settings.strings = {
  prefixAgo: "",
  prefixFromNow: "今から",
  suffixAgo: "前",
  suffixFromNow: "後",
  seconds: "ほんの数秒",
  minute: "約一分",
  minutes: "%d分",
  hour: "大体一時間",
  hours: "大体%d時間位",
  day: "一日",
  days: "%d日ほど",
  month: "大体一ヶ月",
  months: "%dヶ月ほど",
  year: "丁度一年",
  years: "%d年",
  numbers: function (num) {
    if (num > 99999) {
      return num;
    }

    num = num.toString();
    var numbers = ["〇", "一", "二", "三", "四", "五", "六", "七", "八", "九"],
      units = ["", "十", "百", "千", "万"],
      str = "";

      for (var i = 0; i < num.length; i++) {
        var scale = num.length - i - 1;
        var digit = num[i];
        if (digit > 0) {
          if (digit > 1 || (scale != 1 && scale != 2)) {
            str += numbers[digit];
          }
          str += units[scale];
        }
      }

    return str || numbers[0];
  },
  formatter: function (prefix, words, suffix) { return [prefix, words, suffix].join(""); }
}
```

Returns `二十六日ほど前` for "about 26 days ago".
