### PR TITLE
Make word separator i18n-able

### DIFF
--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -45,6 +45,7 @@
         months: "%d months",
         year: "about a year",
         years: "%d years",
+        wordSep: " ",
         numbers: []
       }
     },
@@ -84,7 +85,7 @@
         years < 2 && substitute($l.year, 1) ||
         substitute($l.years, Math.floor(years));
 
-      return $.trim([prefix, words, suffix].join(" "));
+      return $.trim([prefix, words, suffix].join($l.wordSep));
     },
     parse: function(iso8601) {
       var s = $.trim(iso8601);


### PR DESCRIPTION
Most Asian languages uses no word separator, it's pretty none sense to say "1 分鐘 以前" in Chinese, as we never say "1 minute, ago" in English, normally we use "1分鐘以前".
