### PR TITLE
Natural rounding for days, months and years.

### DIFF
--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -76,12 +76,12 @@
         minutes < 45 && substitute($l.minutes, Math.round(minutes)) ||
         minutes < 90 && substitute($l.hour, 1) ||
         hours < 24 && substitute($l.hours, Math.round(hours)) ||
-        hours < 48 && substitute($l.day, 1) ||
-        days < 30 && substitute($l.days, Math.floor(days)) ||
-        days < 60 && substitute($l.month, 1) ||
-        days < 365 && substitute($l.months, Math.floor(days / 30)) ||
-        years < 2 && substitute($l.year, 1) ||
-        substitute($l.years, Math.floor(years));
+        hours < 36 && substitute($l.day, 1) ||
+        days < 30 && substitute($l.days, Math.round(days)) ||
+        days < 45 && substitute($l.month, 1) ||
+        days < 365 && substitute($l.months, Math.round(days / 30)) ||
+        years < 1.5 && substitute($l.year, 1) ||
+        substitute($l.years, Math.round(years));
 
       return $.trim([prefix, words, suffix].join(" "));
     },


### PR DESCRIPTION
I suppose you have a reason why you round for seconds and minutes, so no pressure.

But I think that 47 hours ago is "2 days ago", not "about a day ago".
For instance, if right now is Monday, 15:00, then an entry in my calendar for Wednesday, 14:30 should read "in 2 days", not "in a day".
Similarly, 2010-03-01 happened two years ago, not "about a year ago". :)
