### PR TITLE
Adding $.timeago.settings.offset, useful when dealing with timezones.

### DIFF
--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -137,7 +137,11 @@
   }
 
   function distance(date) {
-    return (new Date().getTime() - date.getTime());
+    var offset = 0;
+    if (typeof $.timeago.settings.offset != 'undefined') {
+      offset = $.timeago.settings.offset;
+    }
+    return (new Date().getTime() - date.getTime() + offset);
   }
 
   // fix for IE6 suckage


### PR DESCRIPTION
My dates are stored in UTC, I don't want UTC time to be used when computing distance() because it will show a wrong time.

$(document).ready(
  function() {
    var now = $.timeago.parse('{date('Y-m-d H:i:s')}'); // standard PHP date, UTC time.
    var offset = now.getTime() - new Date().getTime(); // time difference between server and client.
    $.timeago.settings.offset = offset;
   } 
 );
