### PR TITLE
fixed parsing of timestamps with decimal fraction of a second

### DIFF
--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -91,7 +91,7 @@
     },
     parse: function(iso8601) {
       var s = $.trim(iso8601);
-      s = s.replace(/\.\d\d\d+/,""); // remove milliseconds
+      s = s.replace(/\.\d+/,""); // remove milliseconds
       s = s.replace(/-/,"/").replace(/-/,"/");
       s = s.replace(/T/," ").replace(/Z/," UTC");
       s = s.replace(/([\+\-]\d\d)\:?(\d\d)/," $1$2"); // -04:00 -> -0400

--- a/test/index.html
+++ b/test/index.html
@@ -95,6 +95,7 @@
       <li><abbr id="testParsing7" class="todate" title="1978-12-18 17:17:00"></abbr> [from blank TZ]</li>
       <li><abbr id="testParsing8" class="todate" title="1978-12-18 17:17:00.021Z"></abbr> [from Z with milliseonds]</li>
       <li><abbr id="testParsing9" class="todate" title="1978-12-18 17:17:00.021432Z"></abbr> [from Z with microseonds]</li>
+      <li><abbr id="testParsing10" class="todate" title="1978-12-18 17:17:00.0Z"></abbr> [from Z with milliseonds]</li>
     </ul>
 
     <h2>Wording</h2>
@@ -352,6 +353,10 @@
 
       test("From Z with microseconds", function () {
         ok(($("#testParsing9").html().match(correctMatch)), "Correctly parsed");
+      });
+
+      test("From Z with microseconds", function () {
+        ok(($("#testParsing10").html().match(correctMatch)), "Correctly parsed");
       });
 
       module("Wording");


### PR DESCRIPTION
This fixes a bug in parsing timestamps with a fraction of second component.

The current code works only if the component has at least 3 digits; however it is not required that it has more than 1 digit ( per http://www.w3.org/TR/NOTE-datetime ).
