### PR TITLE
introduced options.lang + automagic mapping for multiple language support..

### DIFF
--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -31,7 +31,8 @@
     settings: {
       refreshMillis: 60000,
       allowFuture: false,
-      strings: {
+      lang: "en",
+      strings: { "en": {
         prefixAgo: null,
         prefixFromNow: null,
         suffixAgo: "ago",
@@ -49,10 +50,10 @@
         years: "%d years",
         wordSeparator: " ",
         numbers: []
-      }
+      }}
     },
     inWords: function(distanceMillis) {
-      var $l = this.settings.strings;
+      var $l = this.settings.strings[this.settings.lang];
       var prefix = $l.prefixAgo;
       var suffix = $l.suffixAgo;
       if (this.settings.allowFuture) {
@@ -127,6 +128,7 @@
   }
 
   function prepareData(element) {
+    $t.settings.lang = ($(element).attr('lang')) ? $(element).attr('lang') : $t.settings.lang;
     element = $(element);
     if (!element.data("timeago")) {
       element.data("timeago", { datetime: $t.datetime(element) });

--- a/locales/jquery.timeago.de.js
+++ b/locales/jquery.timeago.de.js
@@ -1,5 +1,5 @@
 // German
-jQuery.timeago.settings.strings = {
+jQuery.timeago.settings.strings["de"] = {
   prefixAgo: "vor",
   prefixFromNow: "in",
   suffixAgo: "",

--- a/locales/jquery.timeago.en.js
+++ b/locales/jquery.timeago.en.js
@@ -1,5 +1,5 @@
 // English (Template)
-jQuery.timeago.settings.strings = {
+jQuery.timeago.settings.strings["en"] = {
   prefixAgo: null,
   prefixFromNow: null,
   suffixAgo: "ago",


### PR DESCRIPTION
I found myself in a situation where I needed to use multiple localization within a single page load. The solution I came up with does, despite involving a simple change in every localization file, work quite simple.

I am not sure though if I put the language detection code at the correct location. (It currently is at https://github.com/eFrane/jquery-timeago/blob/options.lang/jquery.timeago.js#L131)