### PR TITLE
Clean up our own setInterval calls

### DIFF
--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -113,7 +113,21 @@
 
     var $s = $t.settings;
     if ($s.refreshMillis > 0) {
-      setInterval(function() { self.each(refresh); }, $s.refreshMillis);
+      var intervalId = setInterval(function() {
+        var destroyed = 0
+
+        self.each(function() {
+          if ($(this).parents().filter('html').length === 0) {
+            destroyed++;
+          } else {
+            Function.call(this, refresh);
+          }
+        });
+
+        if (destroyed === self.length) {
+          clearInterval(intervalId);
+        }
+      }, $s.refreshMillis);
     }
     return self;
   };


### PR DESCRIPTION
If you use timeago within an app that destroys the timeago-managed `div`s, you can fairly quickly add LOTS of timers, which slows down the page.

This patch cleans up the `setInterval` calls by doing two things on update:
1. Check if the timer-ed element is in the page. If it isn't, don't update it.
2. Check if every element that we're responsible for updating is not in the page. If none are, kill our timer.

This patch will cause issues with users of timeago that need to update elements that haven't been inserted into the page. I can't think of a reason why you'd want to do that, but something to be aware of nonetheless.
