### PR TITLE
setInterval will clear itself when element is removed from the DOM

### DIFF
--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -119,7 +119,7 @@
           if($(this).parents(":last").is("html") == false) {
             destroyed++;
           } else {
-            Function.call(this, refresh);
+            refresh.call(this);
           }
         });
         if (destroyed === self.length) {


### PR DESCRIPTION
My use-case is an activity feed with only 5 items. However, over the lifetime of the web application, thousands of items pass through the feed.

It was not ideal to have thousands of setInterval calls fire each minute.
