### PR TITLE
Interpret null wordSeparator as empty string

### DIFF
--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -86,7 +86,16 @@
         years < 1.5 && substitute($l.year, 1) ||
         substitute($l.years, Math.round(years));
 
-      var separator = $l.wordSeparator === undefined ?  " " : $l.wordSeparator;
+      switch ($l.wordSeparator) {
+        case undefined:
+          var separator = " ";
+          break;
+        case null:
+          var separator = "";
+          break;
+        default:
+          var separator = $l.wordSeparator;
+      }
       return $.trim([prefix, words, suffix].join(separator));
     },
     parse: function(iso8601) {

--- a/test/index.html
+++ b/test/index.html
@@ -139,6 +139,7 @@
       <li><abbr id="testYoungOldSettings2" class="toyoungold" title="2018304000"></abbr> [23360 days]</li>
 
       <li><abbr id="testNoSpaces1" class="nospaces" title="120"></abbr> [120 sec]</li>
+      <li><abbr id="testNullSpaces1" class="nullspaces" title="120"></abbr> [120 sec]</li>
 
       <li><abbr id="testLatinSettings1" class="tolatin" title="-7200"></abbr> [-120 min]</li>
       <li><abbr id="testLatinSettings2" class="tolatin" title="-60"></abbr> [-60 sec]</li>
@@ -242,6 +243,9 @@
 
       loadNoSpaces();
       $("abbr.nospaces").each(toWords);
+
+      loadNullSpaces();
+      $("abbr.nullspaces").each(toWords);
 
       loadPigLatin();
       $("abbr.tolatin").each(toWords);
@@ -562,6 +566,7 @@
 
       test("wordSeparator", function () {
         ok($("#testNoSpaces1").html().match(/^2minutesago$/), "Settings correctly applied");
+        ok($("#testNullSpaces1").html().match(/^2minutesago$/), "Settings correctly applied");
       });
     })(jQuery);
     //]]>

--- a/test/test_helpers.js
+++ b/test/test_helpers.js
@@ -102,6 +102,13 @@ function loadNoSpaces() {
   });
 }
 
+function loadNullSpaces() {
+  jQuery.extend(jQuery.timeago.settings.strings, {
+    minutes: "%dminutes",
+    wordSeparator: null
+  });
+}
+
 function loadYoungOldYears() {
   jQuery.extend(jQuery.timeago.settings.strings, {
     years: function(value) { return (value < 21) ? "%d young years" : "%d old years"; }


### PR DESCRIPTION
Here's a fix for a `null` wordSeparator being interpreted as `"null"`.
