### PR TITLE
Implemented only one Interval on a page.

### DIFF
--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -48,7 +48,7 @@
 
   $.extend($.timeago, {
     settings: {
-      refreshMillis: 6000,
+      refreshMillis: 60000,
       allowFuture: false,
       localeTitle: false,
       strings: {


### PR DESCRIPTION
This commit will fix jquery.timeago's issue to have an interval
for each timeago element on a page.
By doing this it also removes destroyed elements automatically.

As such, this commit fixes rmm5t/jquery-timeago#96 and
rmm5t/jquery-timeago#90.

Please share your comments. My code might not be the most idiomatic jQuery plugin code ever - please let me know what could be done better in your opinion, as well as let me know if there are any bugs.