### PR TITLE
Add mobile safari support(conform to ios8601)

### DIFF
--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -104,7 +104,7 @@
     parse: function(iso8601) {
       var s = $.trim(iso8601);
       s = s.replace(/\.\d+/,""); // remove milliseconds
-      s = s.replace(/-/,"/").replace(/-/,"/");
+      s = s.replace(/\//,"-").replace(/\//,"-");
       s = s.replace(/T/," ").replace(/Z/," UTC");
       s = s.replace(/([\+\-]\d\d)\:?(\d\d)/," $1$2"); // -04:00 -> -0400
       return new Date(s);


### PR DESCRIPTION
I got 'Invalid Date' Error on mobile safari.
They do not accepts like '2013/05/27T14:59:58+09:00'.
(2013-05-27T14:59:58+09:00 is ok)

So, I changed parse function and I think this is more conformable to iso8601 date format.
