### PR TITLE
Update jquery.timeago.pt-br.js

### DIFF
--- a/locales/jquery.timeago.pt-br.js
+++ b/locales/jquery.timeago.pt-br.js
@@ -2,7 +2,7 @@
 jQuery.timeago.settings.strings = {
    prefixAgo: "há",
    prefixFromNow: "em",
-   suffixAgo: "atrás",
+   suffixAgo: null,
    suffixFromNow: null,
    seconds: "alguns segundos",
    minute: "um minuto",


### PR DESCRIPTION
Removing the pleonasm of having both "há" and "atrás"
