### PR TITLE
Adding a knockout binding extension

### DIFF
--- a/timeago-koext.js
+++ b/timeago-koext.js
@@ -1,0 +1,14 @@
+ko.bindingHandlers.timeago = {
+    init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+        var value = valueAccessor();
+        var valueUnwrapped = ko.unwrap(value);
+        element.title = moment(valueUnwrapped).toISOString();
+        $(element).timeago();
+    },
+    update: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+        var value = valueAccessor();
+        var valueUnwrapped = ko.unwrap(value);
+        element.title = moment(valueUnwrapped).toISOString();
+        $(element).timeago('update', element.title);
+    }
+}


### PR DESCRIPTION
Simple knockout binding extension for knockout bindings with timeago and momentjs. Usage is <div data-bind='timeago: mytimeprop'  />
