### PR TITLE
Create bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,11 @@
+{
+    "name": "jquery-timeago",
+    "version": "1.4.0",
+    "ignore": [
+        "test",
+        "vendor"
+    ],
+    "dependencies": {
+        "jquery": ">=1.6"
+    }
+}


### PR DESCRIPTION
I've created this bower.json manifest to register the library in bower. The version is changed to 1.4.0 because I guest this, and previous commits, can generate a new release. The folders test and vendors are not required in production, so they are ignored and jquery is added as a dependency (due it's a jquery plugin) but I'm not sure about the minimal jquery version required.
