### PR TITLE
Optionally set a cutoff message.

### DIFF
--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -42,6 +42,7 @@
       allowFuture: false,
       localeTitle: false,
       cutoff: 0,
+      cutoffMessage: false,
       strings: {
         prefixAgo: null,
         prefixFromNow: null,
@@ -169,6 +170,9 @@
     if (!isNaN(data.datetime)) {
       if ( $s.cutoff == 0 || distance(data.datetime) < $s.cutoff) {
         $(this).text(inWords(data.datetime));
+      }
+      else if ($s.cutoffMessage && distance(data.datetime) >= $s.cutoff) {
+        $(this).text($s.cutoffMessage.concat(" ", inWords(new Date(new Date().getTime() - $s.cutoff))));
       }
     }
     return this;

--- a/test/index.html
+++ b/test/index.html
@@ -66,6 +66,8 @@
     <h2>Cutoff</h2>
 
     <p>Date that is older than cutoff: <abbr class="timeago cutoff doCutoff" title="1978-12-18">(this should be displayed)</abbr></p>
+    
+    <p>Date that is older than cutoff with message: <abbr class="timeago cutoff withCutoffMessage doCutoffWithCutoffMessage" title="1978-12-18">(you shouldn't see this)</abbr></p>
 
     <p>Date that is newer than cutoff: <abbr class="timeago loaded cutoff dontCutoff">(you shouldn't see this)</abbr></p>
 
@@ -228,7 +230,11 @@
 
       loadCutoffSetting();
       $("abbr.cutoff").timeago();
+      loadCutoffMessageSetting();
+      $("abbr.cutoff.withCutoffMessage").timeago();
+      unloadCutoffMessageSetting();
       unloadCutoffSetting();
+
 
       var tooltip = $("#testTooltip").data("timeago");
 
@@ -314,6 +320,12 @@
         ok(testElements("abbr.doCutoff", function (element) {
           return (element.html() === "(this should be displayed)");
         }), "Cutoff setting working fine");
+      });
+
+      test("should give cutoff message for dates older than cutoff setting", function() {
+        ok(testElements("abbr.doCutoffWithCutoffMessage", function (element) {
+          return (element.html() === "over 7 days ago");
+        }), "Cutoff message setting working fine");
       });
 
       test("should change dates newer than cutoff setting", function () {

--- a/test/test_helpers.js
+++ b/test/test_helpers.js
@@ -30,6 +30,14 @@ function unloadCutoffSetting() {
 	jQuery.timeago.settings.cutoff = 0;
 }
 
+function loadCutoffMessageSetting() {
+	jQuery.timeago.settings.cutoffMessage = "over";
+}
+
+function unloadCutoffMessageSetting() {
+	jQuery.timeago.settings.cutoffMessage = false;
+}
+
 function setupDisposal() {
   jQuery.timeago.settings.refreshMillis = 50;
   $('abbr.disposal').attr("title", iso8601(new Date())).timeago();


### PR DESCRIPTION
Displaying a lot of dates together and using the cutoff setting produces a very inconsistent look. (Some are words, some are dates) This will allow you to benefit from the cutoff feature, but have everything in words.

If you set the cutoffMessage setting to a string, that string will
be displayed before the text version of your cutoff date.
e.g.: {cutoffMessage: "over", cutoff: 7_24_60_60_1000} will produce
"over 7 days ago".
