### PR TITLE
Fix iso8601 parsing in Safari

### DIFF
--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -106,8 +106,8 @@
       s = s.replace(/\.\d+/,""); // remove milliseconds
       s = s.replace(/-/,"/").replace(/-/,"/");
       s = s.replace(/T/," ").replace(/Z/," UTC");
-      s = s.replace(/([\+\-]\d\d)\:?(\d\d)/," $1$2"); // -04:00 -> -0400
-      s = s.replace(/([\+\-]\d\d)$/," $100"); // +09 -> +0900
+      s = s.replace(/([\+\-]\d\d)\:?(\d\d)/,"$1$2"); // -04:00 -> -0400
+      s = s.replace(/([\+\-]\d\d)$/,"$100"); // +09 -> +0900
       return new Date(s);
     },
     datetime: function(elem) {


### PR DESCRIPTION
Previous parsing result:
2014/01/09 01:06:21 UTC +0100

New parsing result:
2014/01/09 01:06:21 UTC+0100

Only in Safari, new Date("2014/01/09 01:06:21 UTC +0100") results in a "Invalid Date". Safari might even be right about not accepting this format.

When removing the space between UTC and the timezone designation, Safari parses the date correctly, as do other browsers.

A test page can be found here: http://jsfiddle.net/4aYGm/7/
