### PR TITLE
Automatic disposal of the timer when element is removed from DOM tree

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -193,6 +193,8 @@
     <h2>Disposal</h2>
     <p><abbr class="disposal disposed"></abbr></p>
     <p><abbr class="disposal notDisposed"></abbr></p>
+    <p><abbr class="disposal autoDisposed"></abbr></p>
+    <p><abbr class="disposal notAutoDisposed"></abbr></p>
   </div>
 
   <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
@@ -601,20 +603,30 @@
         $(".disposal.disposed").timeago('dispose');
         var initialTime_disposedTimeago = $(".disposal.disposed").html();
         var initialTime_activeTimeago = $(".disposal.notDisposed").html();
+        var autoDisposedNode = $(".disposal.autoDisposed").remove();
+        var initialTime_autoDisposedTimeago = autoDisposedNode.html();
+        var notAutoDisposedNode = $(".disposal.notAutoDisposed").remove();
+        var initialTime_notAutoDisposedTimeago = notAutoDisposedNode.html();
 
-        expect(2);
+        expect(4);
         setTimeout(function() {
           var updatedTime_disposedTimeago = $(".disposal.disposed").html();
           var updatedTime_activeTimeago = $(".disposal.notDisposed").html();
+          var updatedTime_autoDisposedTimeago = autoDisposedNode.html();
+          var updatedTime_notAutoDisposedTimeago = notAutoDisposedNode.html();
 
           ok(initialTime_disposedTimeago === updatedTime_disposedTimeago, "A disposed timeago didn't get updated");
           ok(initialTime_activeTimeago !== updatedTime_activeTimeago, "A non-disposed timeago continued to be updated");
+          ok(initialTime_autoDisposedTimeago === updatedTime_autoDisposedTimeago, "A auto-disposed timeago didn't get updated");
+          ok(initialTime_notAutoDisposedTimeago !== updatedTime_notAutoDisposedTimeago, "A non-auto-disposed timeago continued to be updated");
 
           // Dispose still-active timeago
           $(".disposal.notDisposed").timeago('dispose');
+          $(notAutoDisposedNode).timeago('dispose');
           resetRefreshMillis();
           start();
         }, 50);
+
       });
     })(jQuery);
     //]]>

--- a/test/test_helpers.js
+++ b/test/test_helpers.js
@@ -32,7 +32,12 @@ function unloadCutoffSetting() {
 
 function setupDisposal() {
   jQuery.timeago.settings.refreshMillis = 50;
-  $('abbr.disposal').attr("title", iso8601(new Date())).timeago();
+
+  $('abbr.disposal').attr("title", iso8601(new Date()));
+  jQuery.timeago.settings.autoDisposal = true;
+  $('abbr.disposal').timeago();
+  jQuery.timeago.settings.autoDisposal = false;
+  $('abbr.notAutoDisposed').timeago();
 }
 
 function loadPigLatin() {


### PR DESCRIPTION
Hi,

As some other folks requested before, I needed a mechanism to automatically release the timer in case the timeago-enabled elements were removed from the DOM tree. Here is my contribution of the implementation with the unit test cases. Hope it is helpful and high quality enough to get into the main branch.

As I respect the backward compatibility, I made this feature disabled by default and the application needs to set $.timeago.settings.autoDisposal to true to enable it. (Please feel free to change this default behavior if the backward compatibility were not a big concern.)

A small fix was also made to avoid the timer leak in case an element is initialized twice.

The enhanced unit test cases would make sure that the update stops (or does not stop) when an element is removed from DOM if autoDisposal is true (or false).

Best Regards,
Tomoto
