### PR TITLE
Speed increases and process optimizations

### DIFF
--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -3,7 +3,7 @@
  * updating fuzzy timestamps (e.g. "4 minutes ago" or "about 1 day ago").
  *
  * @name timeago
- * @version 1.3.2
+ * @version 2.0.0
  * @requires jQuery v1.2.3+
  * @author Ryan McGeary
  * @modified by Eitan Stadtlander-Miller


### PR DESCRIPTION
Modified the words function from having an average of 5.5 functions called per timeago, to an average of 2.25 functions using a lookup table, this resulted in a speed increase of about 200%. I also removed the calculations for minutes hours days years unless otherwise needed.

I also added the functionality for use with my global timeout jquery plugin found at https://github.com/vipero07/jQuery-plugins/blob/master/jquery.globalTimeout.js . The reasoning for this is so instead of timeago having an interval for each timeago element (that continues to run even if the element is removed from the page). It only uses one timeout. I also set it up to use a timeout with a larger interval or no timeout for greater time differences where updating is not needed. (so pages with a lot of timeago elements use less computational power, and intervals will not stack up as a result of other stuff running). This can probably be made even faster using web workers, but for now this will do.
