### PR TITLE
Changed words var into a table lookup

### DIFF
--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -126,7 +126,7 @@
       }
 
       var seconds = Math.abs(distanceMillis) / 1000,
-          secondLength = (Math.log(seconds) / Math.log(10)) | 0 + 1,
+          secondLength = ((Math.log(seconds) / Math.log(10)) | 0) + 1,
           words = secondLength < 9 ? makeString[secondLength](seconds, $l, distanceMillis) : makeString[8](seconds, $l, distanceMillis);
 
       var separator = $l.wordSeparator || "";

--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -135,7 +135,7 @@
 
       var seconds = Math.abs(distanceMillis) / 1000,
           secondLength = Math.floor(Math.log(seconds) / Math.log(10)) + 1,
-          words = makeString[secondLength] ? makeString[secondLength](seconds, $l, distanceMillis) : makeString[8](seconds, $l, distanceMillis);
+          words = secondLength < 9 ? makeString[secondLength](seconds, $l, distanceMillis) : makeString[8](seconds, $l, distanceMillis);
 
       var separator = $l.wordSeparator || "";
       if ($l.wordSeparator === undefined) { separator = " "; }

--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -86,6 +86,14 @@
                   time < 47304000 && substitute($l.year, 1, $l, distanceMillis) ||
                   substitute($l.years, Math.round(time / 60 / 60 / 24 / 365), $l, distanceMillis); //year
           }
+      ],
+      regex = [
+          /\.\d+/, // milliseconds
+          /-/,
+          /T/,
+          /Z/,
+          /([\+\-]\d\d)\:?(\d\d)/, // -04:00 -> -0400
+          /([\+\-]\d\d)$/ // +09 -> +0900
       ];
 
   $.extend($.timeago, {
@@ -134,12 +142,14 @@
       return $.trim([prefix, words, suffix].join(separator));
     },
     parse: function(iso8601) {
-      var s = $.trim(iso8601);
-      s = s.replace(/\.\d+/,""); // remove milliseconds
-      s = s.replace(/-/,"/").replace(/-/,"/");
-      s = s.replace(/T/," ").replace(/Z/," UTC");
-      s = s.replace(/([\+\-]\d\d)\:?(\d\d)/," $1$2"); // -04:00 -> -0400
-      s = s.replace(/([\+\-]\d\d)$/," $100"); // +09 -> +0900
+      var s = $.trim(iso8601)
+          .replace(regex[0], "") // remove milliseconds
+          .replace(regex[1], "/")
+          .replace(regex[1], "/")
+          .replace(regex[2], " ")
+          .replace(regex[3], " UTC")
+          .replace(regex[4], " $1$2") // -04:00 -> -0400
+          .replace(regex[5], " $100"); // +09 -> +0900
       return new Date(s);
     },
     datetime: function(elem) {

--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -34,7 +34,59 @@
       return inWords($.timeago.datetime(timestamp));
     }
   };
-  var $t = $.timeago;
+  var $t = $.timeago,
+      substitute = function (stringOrFunction, number, $l, distanceMillis) {
+          var string = $.isFunction(stringOrFunction) ? stringOrFunction(number, distanceMillis) : stringOrFunction,
+              value = ($l.numbers && $l.numbers[number]) || number;
+          return string.replace(/%d/i, value);
+      },
+      makeString = [
+          function (time, $l, distanceMillis) {
+              throw new Error("Not a valid number '" + time);
+          },
+          function (time, $l, distanceMillis) {
+              //time is 1 digit long
+              return substitute($l.seconds, Math.round(time), $l, distanceMillis);
+          },
+          function (time, $l, distanceMillis) {
+              //time is 2 digits long
+              return time < 45 && makeString[1](time, $l, distanceMillis) ||
+                  time < 90 && substitute($l.minute, 1, $l, distanceMillis) ||
+                  makeString[3](time, $l, distanceMillis);
+          },
+          function (time, $l, distanceMillis) {
+              //time is 3 digits long
+              return substitute($l.minutes, Math.round(time / 60), $l, distanceMillis); //minute
+          },
+          function (time, $l, distanceMillis) {
+              //time is 4 digits long
+              return time < 2700 && makeString[3](time, $l, distanceMillis) ||
+                  time < 5400 && substitute($l.hour, 1, $l, distanceMillis) ||
+                  makeString[5](time, $l, distanceMillis);
+          },
+          function (time, $l, distanceMillis) {
+              //time is 5 digits long
+              return time < 86400 && substitute($l.hours, Math.round(time / 60 / 60), $l, distanceMillis) || //hour
+                  substitute($l.day, 1, $l, distanceMillis);
+          },
+          function (time, $l, distanceMillis) {
+              //time is 6 digits long
+              return time < 151200 && substitute($l.day, 1, $l, distanceMillis) ||
+                  substitute($l.days, Math.round(time / 60 / 60 / 24), $l, distanceMillis); //day
+          },
+          function (time, $l, distanceMillis) {
+              //time is 7 digits long
+              return time < 2592000 && makeString[6](time, $l, distanceMillis) ||
+                  time < 3888000 && substitute($l.month, 1, $l, distanceMillis) ||
+                  substitute($l.months, Math.round(time / 60 / 60 / 24 / 30), $l, distanceMillis); //month
+          },
+          function (time, $l, distanceMillis) {
+              //time is 8 digits long
+              return time < 31536000 && makeString[7](time, $l, distanceMillis) ||
+                  time < 47304000 && substitute($l.year, 1, $l, distanceMillis) ||
+                  substitute($l.years, Math.round(time / 60 / 60 / 24 / 365), $l, distanceMillis); //year
+          }
+      ];
 
   $.extend($.timeago, {
     settings: {
@@ -73,29 +125,9 @@
         }
       }
 
-      var seconds = Math.abs(distanceMillis) / 1000;
-      var minutes = seconds / 60;
-      var hours = minutes / 60;
-      var days = hours / 24;
-      var years = days / 365;
-
-      function substitute(stringOrFunction, number) {
-        var string = $.isFunction(stringOrFunction) ? stringOrFunction(number, distanceMillis) : stringOrFunction;
-        var value = ($l.numbers && $l.numbers[number]) || number;
-        return string.replace(/%d/i, value);
-      }
-
-      var words = seconds < 45 && substitute($l.seconds, Math.round(seconds)) ||
-        seconds < 90 && substitute($l.minute, 1) ||
-        minutes < 45 && substitute($l.minutes, Math.round(minutes)) ||
-        minutes < 90 && substitute($l.hour, 1) ||
-        hours < 24 && substitute($l.hours, Math.round(hours)) ||
-        hours < 42 && substitute($l.day, 1) ||
-        days < 30 && substitute($l.days, Math.round(days)) ||
-        days < 45 && substitute($l.month, 1) ||
-        days < 365 && substitute($l.months, Math.round(days / 30)) ||
-        years < 1.5 && substitute($l.year, 1) ||
-        substitute($l.years, Math.round(years));
+      var seconds = Math.abs(distanceMillis) / 1000,
+          secondLength = Math.floor(seconds).toString().length,
+          words = typeof makeString[secondLength] != "undefined" ? makeString[secondLength](seconds, $l, distanceMillis) : makeString[8](seconds, $l, distanceMillis);
 
       var separator = $l.wordSeparator || "";
       if ($l.wordSeparator === undefined) { separator = " "; }

--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -126,7 +126,7 @@
       }
 
       var seconds = Math.abs(distanceMillis) / 1000,
-          secondLength = Math.floor(seconds/10)+1,
+          secondLength = Math.floor(Math.log(seconds) / Math.log(10)) + 1,
           words = typeof makeString[secondLength] != "undefined" ? makeString[secondLength](seconds, $l, distanceMillis) : makeString[8](seconds, $l, distanceMillis);
 
       var separator = $l.wordSeparator || "";

--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -126,7 +126,7 @@
       }
 
       var seconds = Math.abs(distanceMillis) / 1000,
-          secondLength = Math.floor(Math.log(seconds) / Math.log(10)) + 1,
+          secondLength = (Math.log(seconds) / Math.log(10)) | 0 + 1,
           words = secondLength < 9 ? makeString[secondLength](seconds, $l, distanceMillis) : makeString[8](seconds, $l, distanceMillis);
 
       var separator = $l.wordSeparator || "";

--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -86,14 +86,6 @@
                   time < 47304000 && substitute($l.year, 1, $l, distanceMillis) ||
                   substitute($l.years, Math.round(time / 60 / 60 / 24 / 365), $l, distanceMillis); //year
           }
-      ],
-      regex = [
-          /\.\d+/, // milliseconds
-          /-/,
-          /T/,
-          /Z/,
-          /([\+\-]\d\d)\:?(\d\d)/, // -04:00 -> -0400
-          /([\+\-]\d\d)$/ // +09 -> +0900
       ];
 
   $.extend($.timeago, {
@@ -143,13 +135,14 @@
     },
     parse: function(iso8601) {
       var s = $.trim(iso8601)
-          .replace(regex[0], "") // remove milliseconds
-          .replace(regex[1], "/")
-          .replace(regex[1], "/")
-          .replace(regex[2], " ")
-          .replace(regex[3], " UTC")
-          .replace(regex[4], " $1$2") // -04:00 -> -0400
-          .replace(regex[5], " $100"); // +09 -> +0900
+          .replace(/\.\d+/, "") // remove milliseconds
+          .replace(/-/, "/")
+          .replace(/-/, "/")
+          .replace(/T/, " ")
+          .replace(/Z/, " UTC")
+          .replace(/([\+\-]\d\d)\:?(\d\d)/, " $1$2") // -04:00 -> -0400
+          .replace(/([\+\-]\d\d)$/, " $100"); // +09 -> +0900
+          
       return new Date(s);
     },
     datetime: function(elem) {

--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -135,7 +135,7 @@
 
       var seconds = Math.abs(distanceMillis) / 1000,
           secondLength = Math.floor(Math.log(seconds) / Math.log(10)) + 1,
-          words = typeof makeString[secondLength] != "undefined" ? makeString[secondLength](seconds, $l, distanceMillis) : makeString[8](seconds, $l, distanceMillis);
+          words = makeString[secondLength] ? makeString[secondLength](seconds, $l, distanceMillis) : makeString[8](seconds, $l, distanceMillis);
 
       var separator = $l.wordSeparator || "";
       if ($l.wordSeparator === undefined) { separator = " "; }

--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -126,7 +126,7 @@
       }
 
       var seconds = Math.abs(distanceMillis) / 1000,
-          secondLength = Math.floor(seconds).toString().length,
+          secondLength = Math.floor(seconds/10)+1,
           words = typeof makeString[secondLength] != "undefined" ? makeString[secondLength](seconds, $l, distanceMillis) : makeString[8](seconds, $l, distanceMillis);
 
       var separator = $l.wordSeparator || "";


### PR DESCRIPTION
Modified words var so it uses a table lookup to decrease the cost of running timeago calculations. This should result in a notable speed increase. Instead of relying on a bunch of or statements where it would average 5.5 function calls per timeago, it now should now average 2.25. Also moved calculations of minute hour day and year so it only calculates them when needed.

Here is a test showing the speed differences.
http://jsperf.com/timeago-speed-test

It also passes the current test suite.

P.S.
My apologies for the earlier pull request, I'll submit the timeout fix a little later tonight.
