### PR TITLE
Fixed bug with cutoff and allowFuture

### DIFF
--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -179,7 +179,7 @@
     var $s = $t.settings;
 
     if (!isNaN(data.datetime)) {
-      if ( $s.cutoff == 0 || distance(data.datetime) < $s.cutoff) {
+      if ( $s.cutoff == 0 || Math.abs(distance(data.datetime)) < $s.cutoff) {
         $(this).text(inWords(data.datetime));
       }
     }


### PR DESCRIPTION
To reproduce the bug use these settings: 

``` js
    $.timeago.settings.cutoff = 7 * 86400000;// one week in milliseconds
    $.timeago.settings.allowFuture = true
```

You will se that the cutoff have no effect on a future date.
