### PR TITLE
Improved the Hebrew translation

### DIFF
--- a/locales/jquery.timeago.he.js
+++ b/locales/jquery.timeago.he.js
@@ -2,17 +2,15 @@
 jQuery.timeago.settings.strings = {
   prefixAgo: "לפני",
   prefixFromNow: "עוד",
-  suffixAgo: "",
-  suffixFromNow: "",
   seconds: "פחות מדקה",
   minute: "דקה",
   minutes: "%d דקות",
   hour: "שעה",
-  hours: "%d שעות",
+  hours: function(number){return (number==2) ? "שעתיים" : "%d שעות"},
   day: "יום",
-  days: "%d ימים",
+  days: function(number){return (number==2) ? "יומיים" : "%d ימים"},
   month: "חודש",
-  months: "%d חודשים",
+  months: function(number){return (number==2) ? "חודשיים" : "%d חודשים"},
   year: "שנה",
-  years: "%d שנים"
+  years: function(number){return (number==2) ? "שנתיים" : "%d שנים"}
 };


### PR DESCRIPTION
There's a special Hebrew form for two hours/days/months/years. Also, removed two useless lines.
