### PR TITLE
Add spm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "timeago",
+  "version": "1.4.1",
+  "title": "jQuery Timeago",
+  "author": {
+    "name": "Ryan McGeary",
+    "email": "ryan@mcgeary.org",
+    "url": "http://ryan.mcgeary.org/"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://opensource.org/licenses/mit-license.php"
+    }
+  ],
+  "dependencies": {
+    "jquery": ">=1.2.3"
+  },
+  "description": "jQuery plugin that makes it easy to support automatically updating fuzzy timestamps (e.g. \"4 minutes ago\" or \"about 1 day ago\").",
+  "keywords": [
+    "time",
+    "microformat"
+  ],
+  "homepage": "http://timeago.yarp.com/",
+  "docs": "https://github.com/rmm5t/jquery-timeago",
+  "demo": "http://timeago.yarp.com/",
+  "download": "http://timeago.yarp.com/jquery.timeago.js",
+  "bugs": "https://github.com/rmm5t/jquery-timeago/issues",
+  "maintainers": [],
+  "spm": {
+    "main": "jquery.timeago.js"
+  }
+}


### PR DESCRIPTION
A nicer package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/jquery-timeago

---

It is a package manager based on [Sea.js](https://github.com/seajs/seajs) which is a popular module loader in China.

spmjs focus in browser side. We supply a complete lifecycle managment of package by using [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of jquery-timeago in spmjs, I can add it for your account after signing in http://spmjs.io.
