### PR TITLE
Add support for UTC dates

### DIFF
--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -213,8 +213,8 @@
   }
 
   function distance(date) {
+    var now = new Date();
     if ($t.settings.useUTC) {
-      var now = new Date();
       var utc = new Date(
       	now.getUTCFullYear(),
 	now.getUTCMonth(),
@@ -224,7 +224,7 @@
 	now.getUTCSeconds());
 	return (utc.getTime() - date.getTime());
     } else {
-	return (new Date().getTime() - date.getTime());
+	return (now.getTime() - date.getTime());
     }
   }
 


### PR DESCRIPTION
This pull request adds a new setting 'useUTC'. When set to true, the plugin uses current UTC datetime instead of local datetime. Very useful when the server provided timestamp is in UTC.
