### PR TITLE
Sinhalese language

### DIFF
--- a/locales/jquery.timeago.si.js
+++ b/locales/jquery.timeago.si.js
@@ -1,0 +1,18 @@
+// Sinhalese (SI)
+jQuery.timeago.settings.strings = {
+  prefixAgo: null,
+  prefixFromNow: null,
+  suffixAgo: "පෙර",
+  suffixFromNow: "පසුව",
+  seconds: "තත්පර කිහිපයකට",
+  minute: "මිනිත්තුවකට පමණ",
+  minutes: "මිනිත්තු %d කට",
+  hour: "පැයක් පමණ ",
+  hours: "පැය %d කට  පමණ",
+  day: "දවසක ට",
+  days: "දවස් %d කට ",
+  month: "මාසයක් පමණ",
+  months: "මාස %d කට",
+  year: "වසරක් පමණ",
+  years: "වසරක් %d කට පමණ"
+};


### PR DESCRIPTION
Hi Ryan,
Big fan of your awesome plugin. I use it my Sinhalese (national language of Sri Lanka, my home country) sites, so I thought to add a Sinhalese translation.  There are many Sinhala news paper sites and other publications that could benefit from the plugin.

 - https://en.wikipedia.org/wiki/Sinhalese_language
 - https://en.wikipedia.org/wiki/Sinhala_alphabet

Please take a look when you have time.
Thanks.
![si](https://cloud.githubusercontent.com/assets/811553/7429392/152d9a74-f01e-11e4-9148-38b515c4b51d.png)
