### PR TITLE
Making compatible with CommonJS for browserify/webpack

### DIFF
--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -18,6 +18,8 @@
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
     define(['jquery'], factory);
+  } if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/package.json
+++ b/package.json
@@ -29,5 +29,9 @@
   "maintainers": [],
   "spm": {
     "main": "jquery.timeago.js"
-  }
+  },
+  "browser": {
+    "timeago": "./node_modules/timeago/jquery.timeago.js"
+  },
+  "main": "jquery.timeago.js"
 }


### PR DESCRIPTION
This change checks to see if the module is getting loaded in a CommonJS environment (AKA browserify/webpack) and acts appropriately. 

This is related to #231, though it only partially resolves the problem.

You still cannot load this module server-side due to the dependency on jquery.extend, as jquery doesn't load without a window object. 
