### PR TITLE
Make visibility check optional

### DIFF
--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -45,7 +45,7 @@
       allowFuture: false,
       localeTitle: false,
       cutoff: 0,
-      checkVisibility: true,
+      autoDispose: true,
       strings: {
         prefixAgo: null,
         prefixFromNow: null,
@@ -181,7 +181,7 @@
     var $s = $t.settings;
 
     //check if it's still visible
-    if($s.checkVisibility && !$.contains(document.documentElement,this)){
+    if($s.autoDispose && !$.contains(document.documentElement,this)){
       //stop if it has been removed
       $(this).timeago("dispose");
       return this;

--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -45,6 +45,7 @@
       allowFuture: false,
       localeTitle: false,
       cutoff: 0,
+      checkVisibility: true,
       strings: {
         prefixAgo: null,
         prefixFromNow: null,
@@ -177,15 +178,16 @@
   };
 
   function refresh() {
+    var $s = $t.settings;
+
     //check if it's still visible
-    if(!$.contains(document.documentElement,this)){
+    if($s.checkVisibility && !$.contains(document.documentElement,this)){
       //stop if it has been removed
       $(this).timeago("dispose");
       return this;
     }
 
     var data = prepareData(this);
-    var $s = $t.settings;
 
     if (!isNaN(data.datetime)) {
       if ( $s.cutoff == 0 || Math.abs(distance(data.datetime)) < $s.cutoff) {


### PR DESCRIPTION
There are use-cases where `document.documentElement` does not contain the element.

In my case I was contributing to a Chrome Extension, and `document.documentElement` contained the background page only, which made the plugin stop working.

There might be a smarter way to do this, i.e. finding out if the element is visible - maybe by specifying the parent in some way. But it is rather an edge case, so this solution should be sufficient.