### PR TITLE
add composer file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
     "component": {
       "scripts": [
         "jquery.timeago.js"
+      ],
+      "files": [
+        "locales/jquery.timeago.*.js"
       ]
     }
   }

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
     "time",
     "microformat"
   ],
+  "require": {
+    "components/jquery": ">=1.2.3"
+  },
   "extra": {
     "component": {
       "scripts": [

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
   "name": "rmm5t/jquery-timeago",
-  "type": "component",
   "description": "jQuery plugin that makes it easy to support automatically updating fuzzy timestamps (e.g. \"4 minutes ago\" or \"about 1 day ago\").",
   "license": "MIT",
   "homepage": "http://timeago.yarp.com/",
@@ -17,7 +16,11 @@
     "time",
     "microformat"
   ],
-  "require": {
-    "robloach/component-installer": "*"
+  "extra": {
+    "component": {
+      "scripts": [
+        "jquery.timeago.js"
+      ]
+    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,23 @@
+{
+  "name": "rmm5t/jquery-timeago",
+  "type": "component",
+  "description": "jQuery plugin that makes it easy to support automatically updating fuzzy timestamps (e.g. \"4 minutes ago\" or \"about 1 day ago\").",
+  "license": "MIT",
+  "homepage": "http://timeago.yarp.com/",
+  "authors": [
+    {
+      "name": "Ryan McGeary",
+      "email": "ryan@mcgeary.org"
+    }
+  ],
+  "support": {
+    "issues": "https://github.com/rmm5t/jquery-timeago/issues"
+  },
+  "keywords": [
+    "time",
+    "microformat"
+  ],
+  "require": {
+    "robloach/component-installer": "*"
+  }
+}


### PR DESCRIPTION
adds support for loading assets via [component-installer](https://github.com/RobLoach/component-installer).

unless you publish this package on packagist.org, one can just add to their composer.json:

```json
        {
            "type": "vcs",
            "url": "https://github.com/rmm5t/jquery-timeago"
        },
...
    "require": {
        "rmm5t/jquery-timeago": "*",

```