### PR TITLE
Add ability to specify time in epoch milliseconds

### DIFF
--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -46,6 +46,7 @@
       localeTitle: false,
       cutoff: 0,
       autoDispose: true,
+	  asEpoch: false, // specifies that the value for datetime attribute is specified in milliseconds (unix epoch)
       strings: {
         prefixAgo: null,
         prefixFromNow: null,
@@ -117,13 +118,18 @@
     },
 
     parse: function(iso8601) {
-      var s = $.trim(iso8601);
-      s = s.replace(/\.\d+/,""); // remove milliseconds
-      s = s.replace(/-/,"/").replace(/-/,"/");
-      s = s.replace(/T/," ").replace(/Z/," UTC");
-      s = s.replace(/([\+\-]\d\d)\:?(\d\d)/," $1$2"); // -04:00 -> -0400
-      s = s.replace(/([\+\-]\d\d)$/," $100"); // +09 -> +0900
-      return new Date(s);
+	  if(!this.settings.asEpoch) {
+        var s = $.trim(iso8601);
+        s = s.replace(/\.\d+/,""); // remove milliseconds
+        s = s.replace(/-/,"/").replace(/-/,"/");
+        s = s.replace(/T/," ").replace(/Z/," UTC");
+        s = s.replace(/([\+\-]\d\d)\:?(\d\d)/," $1$2"); // -04:00 -> -0400
+        s = s.replace(/([\+\-]\d\d)$/," $100"); // +09 -> +0900
+        return new Date(s);
+	  }
+	  
+	  // return the date from milliseconds
+	  return new Date(Number(iso8601));
     },
     datetime: function(elem) {
       var iso8601 = $t.isTime(elem) ? $(elem).attr("datetime") : $(elem).attr("title");

--- a/test/index.html
+++ b/test/index.html
@@ -206,6 +206,13 @@
       <li><abbr id="testAllowPastFalse1" class="doNotAllowPast" title="2008-01-01T09:24:17Z">(you shouldn't see this)</abbr></li>
       <li><abbr id="testAllowPastAndFutureFalse" title="2008-01-01T09:24:17Z"></abbr></li>
     </ul>
+	
+	<h2>Using absolute epoch times</h2>
+	
+	<ul>
+		<li><abbr id="epoch1" class="asEpoch" title="1451608200066">(you shouldn't see this)</abbr> (from Jan 1, 2016, 00:30 hrs) </li>
+		<li><abbr id="epoch2" class="asEpoch" title="7762955400756">(you shouldn't see this)</abbr> (from Jan 1, 2216, 00:30 hrs, future) </li>
+	</ul>
 
     <h2>Disposal</h2>
     <p><abbr class="disposal disposed"></abbr></p>
@@ -223,7 +230,7 @@
         var elements       = $(selector);
         var numberOfTests  = elements.length;
         var numberOfPasses = 0;
-
+		
         elements.each(function () {
           if (test($(this))) { numberOfPasses++; }
         });
@@ -235,6 +242,9 @@
         var string = $.timeago.inWords(parseInt(this.title, 10) * 1000);
         $(this).text(string);
       }
+
+	  var defaultSettings = {};
+	  $.extend(defaultSettings, jQuery.timeago.settings);
 
       $.timeago.settings.allowFuture = true;
 
@@ -268,6 +278,14 @@
       $("abbr.doNotAllowPast").timeago();
       unloadDoNotAllowPast();
 
+	  // reload settings
+	  var currentSettings = {};
+	  $.extend(currentSettings, jQuery.timeago.settings);
+	  jQuery.timeago.settings = defaultSettings;
+	  jQuery.timeago.settings.asEpoch = true;
+	  $("abbr.asEpoch").timeago();
+	  jQuery.timeago.settings = currentSettings;
+	  
       setupDisposal();
 
       loadYoungOldYears();
@@ -667,6 +685,13 @@
           $.timeago.settings.allowFuture = origAllowFuture;
           $.timeago.settings.allowPast = origAllowPast;
         }
+      });
+	  
+	  module("As Epoch");
+	  test("Text in abbr tag should be replaced correctly when time is specified in epoch millis", function () {
+        ok(testElements("abbr.asEpoch", function (element) {
+          return (element.html() !== "(you shouldn't see this)");
+        }), "All text was replaced");
       });
 
       module("Disposal");


### PR DESCRIPTION
This pull request adds the ability to specify the time values in epoch milliseconds. Back-end databases usually store the date/time values as `long` numbers in epoch millis so that it can be properly converted to correct time depending on the user's time-zone where the data is being rendered.

In one of our project, we needed the same functionality and adding a properly formatted ISO 8601 date was adding to the cost of rendering on the server. Thus, we hacked in to the code to add a new `settings` parameter called as `asEpoch` (as a `boolean`) to signify that the values will be specified in epoch millis than as ISO 8601 strings.

When this setting parameter is set to `true`, the values are directly parsed using `new Date(Number(text))` - rest of the functionality remains the same.