### PR TITLE
FIxed Slovenian grammar for months

### DIFF
--- a/locales/jquery.timeago.sl.js
+++ b/locales/jquery.timeago.sl.js
@@ -28,7 +28,7 @@
         },
         month: "en mesec",
         months: function (value) {
-            return numpf(value, ["%d mescov", "%d mesec", "%d mesca", "%d mesce"]);
+            return numpf(value, ["%d mesecev", "%d mesec", "%d meseca", "%d mesece"]);
         },
         year: "eno leto",
         years: function (value) {


### PR DESCRIPTION
The grammar for months is incorrect.