### PR TITLE
Return original time string from title attribute if it is set

### DIFF
--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -192,6 +192,10 @@
     if (!isNaN(data.datetime)) {
       if ( $s.cutoff == 0 || Math.abs(distance(data.datetime)) < $s.cutoff) {
         $(this).text(inWords(data.datetime));
+      } else {
+        if ($(this).attr('title').length > 0) {
+            $(this).text($(this).attr('title'));
+        }
       }
     }
     return this;


### PR DESCRIPTION
After cut off time has passed, original time string should be restored.