### PR TITLE
[TASK] use strict in all scripts except for the locales

### DIFF
--- a/contrib/timeago-koext.js
+++ b/contrib/timeago-koext.js
@@ -1,11 +1,13 @@
 ko.bindingHandlers.timeago = {
     init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+        'use strict';
         var value = valueAccessor();
         var valueUnwrapped = ko.unwrap(value);
         element.title = moment(valueUnwrapped).toISOString();
         $(element).timeago();
     },
     update: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+        'use strict';
         var value = valueAccessor();
         var valueUnwrapped = ko.unwrap(value);
         element.title = moment(valueUnwrapped).toISOString();

--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -15,6 +15,7 @@
  */
 
 (function (factory) {
+  'use strict';
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
     define(['jquery'], factory);
@@ -25,6 +26,7 @@
     factory(jQuery);
   }
 }(function ($) {
+  'use strict';
   $.timeago = function(timestamp) {
     if (timestamp instanceof Date) {
       return inWords(timestamp);

--- a/test/index.html
+++ b/test/index.html
@@ -219,6 +219,8 @@
   <script type="text/javascript">
     //<![CDATA[
     (function ($) {
+      'use strict';
+
       function testElements(selector, test) {
         var elements       = $(selector);
         var numberOfTests  = elements.length;

--- a/test/test_helpers.js
+++ b/test/test_helpers.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var zeropad = function (num) {
   return ((num < 10) ? '0' : '') + num;
 };


### PR DESCRIPTION
This will help in catching bugs connected to no-quite-clean programming.

The "use strict" lines are placed so that production code of projects
using this library will not be automatically set to strict mode.