### PR TITLE
[CLEANUP] Drop the CDATA from the script tags

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -217,7 +217,6 @@
   <script src="../jquery.timeago.js"></script>
   <script src="test_helpers.js" type="text/javascript"></script>
   <script type="text/javascript">
-    //<![CDATA[
     (function ($) {
       function testElements(selector, test) {
         var elements       = $(selector);
@@ -693,7 +692,6 @@
         }, 50);
       });
     })(jQuery);
-    //]]>
   </script>
 </body>
 </html>


### PR DESCRIPTION
CDATA is not needed anymore in modern browsers.