### PR TITLE
AMD support for locales

### DIFF
--- a/locales/jquery.timeago.af.js
+++ b/locales/jquery.timeago.af.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.af.js
+++ b/locales/jquery.timeago.af.js
@@ -1,20 +1,32 @@
 // Afrikaans
-jQuery.timeago.settings.strings = {
-  prefixAgo: null,
-  prefixFromNow: null,
-  suffixAgo: "gelede",
-  suffixFromNow: "van nou af",
-  seconds: "%d sekondes",
-  minute: "1 minuut",
-  minutes: "%d minute",
-  hour: "1 uur",
-  hours: "%d ure",
-  day: "1 dag",
-  days: "%d dae",
-  month: "1 maand",
-  months: "%d maande",
-  year: "1 jaar",
-  years: "%d jaar",
-  wordSeparator: " ",
-  numbers: []
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: null,
+    suffixAgo: "gelede",
+    suffixFromNow: "van nou af",
+    seconds: "%d sekondes",
+    minute: "1 minuut",
+    minutes: "%d minute",
+    hour: "1 uur",
+    hours: "%d ure",
+    day: "1 dag",
+    days: "%d dae",
+    month: "1 maand",
+    months: "%d maande",
+    year: "1 jaar",
+    years: "%d jaar",
+    wordSeparator: " ",
+    numbers: []
+  };
+}));

--- a/locales/jquery.timeago.ar.js
+++ b/locales/jquery.timeago.ar.js
@@ -1,9 +1,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.ar.js
+++ b/locales/jquery.timeago.ar.js
@@ -1,96 +1,107 @@
-(function() {
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
   function numpf(n, a) {
     return a[plural=n===0 ? 0 : n===1 ? 1 : n===2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5];
   }
 
-jQuery.timeago.settings.strings = {
-    prefixAgo: "منذ",
-    prefixFromNow: "بعد",
-    suffixAgo: null,
-    suffixFromNow: null, // null OR "من الآن"
-    second: function(value) { return numpf(value, [
-      'أقل من ثانية',
-       'ثانية واحدة',
-       'ثانيتين',
-       '%d ثوانٍ',
-       '%d ثانية',
-       '%d ثانية']); },
-    seconds: function(value) { return numpf(value, [
-      'أقل من ثانية',
-       'ثانية واحدة',
-       'ثانيتين',
-       '%d ثوانٍ',
-       '%d ثانية',
-       '%d ثانية']); },
-    minute: function(value) { return numpf(value, [
-      'أقل من دقيقة',
-       'دقيقة واحدة',
-       'دقيقتين',
-       '%d دقائق',
-       '%d دقيقة',
-       'دقيقة']); },
-    minutes: function(value) { return numpf(value, [
-      'أقل من دقيقة',
-       'دقيقة واحدة',
-       'دقيقتين',
-       '%d دقائق',
-       '%d دقيقة',
-       'دقيقة']); },
-    hour:  function(value) { return numpf(value, [
-      'أقل من ساعة',
-       'ساعة واحدة',
-       'ساعتين',
-       '%d ساعات',
-       '%d ساعة',
-       '%d ساعة']); },
-    hours: function(value) { return numpf(value, [
-      'أقل من ساعة',
-       'ساعة واحدة',
-       'ساعتين',
-       '%d ساعات',
-       '%d ساعة',
-       '%d ساعة']); },
-    day:  function(value) { return numpf(value, [
-      'أقل من يوم',
-       'يوم واحد',
-       'يومين',
-       '%d أيام',
-       '%d يومًا',
-       '%d يوم']); },
-    days: function(value) { return numpf(value, [
-      'أقل من يوم',
-       'يوم واحد',
-       'يومين',
-       '%d أيام',
-       '%d يومًا',
-       '%d يوم']); },
-    month:  function(value) { return numpf(value, [
-      'أقل من شهر',
-       'شهر واحد',
-       'شهرين',
-       '%d أشهر',
-       '%d شهرًا',
-       '%d شهر']); },
-    months: function(value) { return numpf(value, [
-      'أقل من شهر',
-       'شهر واحد',
-       'شهرين',
-       '%d أشهر',
-       '%d شهرًا',
-       '%d شهر']); },
-    year:  function(value) { return numpf(value,  [
-      'أقل من عام',
-       'عام واحد',
-       '%d عامين',
-       '%d أعوام',
-       '%d عامًا']);
-     },
-    years: function(value) { return numpf(value,  [
-      'أقل من عام',
-       'عام واحد',
-       'عامين',
-       '%d أعوام',
-       '%d عامًا',
-       '%d عام']);}
+  $.timeago.settings.strings = {
+      prefixAgo: "منذ",
+      prefixFromNow: "بعد",
+      suffixAgo: null,
+      suffixFromNow: null, // null OR "من الآن"
+      second: function(value) { return numpf(value, [
+        'أقل من ثانية',
+         'ثانية واحدة',
+         'ثانيتين',
+         '%d ثوانٍ',
+         '%d ثانية',
+         '%d ثانية']); },
+      seconds: function(value) { return numpf(value, [
+        'أقل من ثانية',
+         'ثانية واحدة',
+         'ثانيتين',
+         '%d ثوانٍ',
+         '%d ثانية',
+         '%d ثانية']); },
+      minute: function(value) { return numpf(value, [
+        'أقل من دقيقة',
+         'دقيقة واحدة',
+         'دقيقتين',
+         '%d دقائق',
+         '%d دقيقة',
+         'دقيقة']); },
+      minutes: function(value) { return numpf(value, [
+        'أقل من دقيقة',
+         'دقيقة واحدة',
+         'دقيقتين',
+         '%d دقائق',
+         '%d دقيقة',
+         'دقيقة']); },
+      hour:  function(value) { return numpf(value, [
+        'أقل من ساعة',
+         'ساعة واحدة',
+         'ساعتين',
+         '%d ساعات',
+         '%d ساعة',
+         '%d ساعة']); },
+      hours: function(value) { return numpf(value, [
+        'أقل من ساعة',
+         'ساعة واحدة',
+         'ساعتين',
+         '%d ساعات',
+         '%d ساعة',
+         '%d ساعة']); },
+      day:  function(value) { return numpf(value, [
+        'أقل من يوم',
+         'يوم واحد',
+         'يومين',
+         '%d أيام',
+         '%d يومًا',
+         '%d يوم']); },
+      days: function(value) { return numpf(value, [
+        'أقل من يوم',
+         'يوم واحد',
+         'يومين',
+         '%d أيام',
+         '%d يومًا',
+         '%d يوم']); },
+      month:  function(value) { return numpf(value, [
+        'أقل من شهر',
+         'شهر واحد',
+         'شهرين',
+         '%d أشهر',
+         '%d شهرًا',
+         '%d شهر']); },
+      months: function(value) { return numpf(value, [
+        'أقل من شهر',
+         'شهر واحد',
+         'شهرين',
+         '%d أشهر',
+         '%d شهرًا',
+         '%d شهر']); },
+      year:  function(value) { return numpf(value,  [
+        'أقل من عام',
+         'عام واحد',
+         '%d عامين',
+         '%d أعوام',
+         '%d عامًا']);
+       },
+      years: function(value) { return numpf(value,  [
+        'أقل من عام',
+         'عام واحد',
+         'عامين',
+         '%d أعوام',
+         '%d عامًا',
+         '%d عام']);}
+    };
   };
-})();
+}));

--- a/locales/jquery.timeago.az-short.js
+++ b/locales/jquery.timeago.az-short.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.az-short.js
+++ b/locales/jquery.timeago.az-short.js
@@ -1,20 +1,33 @@
 // Azerbaijani shortened
-jQuery.timeago.settings.strings = {
-  prefixAgo: null,
-  prefixFromNow: null,
-  suffixAgo: "",
-  suffixFromNow: "",
-  seconds: '1 dəq',
-  minute: '1 dəq',
-  minutes: '%d dəq',
-  hour: '1 saat',
-  hours: '%d saat',
-  day: '1 gün',
-  days: '%d gün',
-  month: '1 ay',
-  months: '%d ay',
-  year: '1 il',
-  years: '%d il',
-  wordSeparator: '',
-  numbers: []
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  // Azerbaijani shortened
+  $.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: null,
+    suffixAgo: "",
+    suffixFromNow: "",
+    seconds: '1 dəq',
+    minute: '1 dəq',
+    minutes: '%d dəq',
+    hour: '1 saat',
+    hours: '%d saat',
+    day: '1 gün',
+    days: '%d gün',
+    month: '1 ay',
+    months: '%d ay',
+    year: '1 il',
+    years: '%d il',
+    wordSeparator: '',
+    numbers: []
+  };
+}));

--- a/locales/jquery.timeago.az.js
+++ b/locales/jquery.timeago.az.js
@@ -1,20 +1,32 @@
 // Azerbaijani
-jQuery.timeago.settings.strings = {
-  prefixAgo: null,
-  prefixFromNow: null,
-  suffixAgo: 'əvvəl',
-  suffixFromNow: 'sonra',
-  seconds: 'saniyələr',
-  minute: '1 dəqiqə',
-  minutes: '%d dəqiqə',
-  hour: '1 saat',
-  hours: '%d saat',
-  day: '1 gün',
-  days: '%d gün',
-  month: '1 ay',
-  months: '%d ay',
-  year: '1 il',
-  years: '%d il',
-  wordSeparator: '',
-  numbers: []
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: null,
+    suffixAgo: 'əvvəl',
+    suffixFromNow: 'sonra',
+    seconds: 'saniyələr',
+    minute: '1 dəqiqə',
+    minutes: '%d dəqiqə',
+    hour: '1 saat',
+    hours: '%d saat',
+    day: '1 gün',
+    days: '%d gün',
+    month: '1 ay',
+    months: '%d ay',
+    year: '1 il',
+    years: '%d il',
+    wordSeparator: '',
+    numbers: []
+  };
+}));

--- a/locales/jquery.timeago.az.js
+++ b/locales/jquery.timeago.az.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.bg.js
+++ b/locales/jquery.timeago.bg.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.bg.js
+++ b/locales/jquery.timeago.bg.js
@@ -1,18 +1,30 @@
 // Bulgarian
-jQuery.timeago.settings.strings = {
-  prefixAgo: "преди",
-  prefixFromNow: "след",
-  suffixAgo: null,
-  suffixFromNow: null,
-  seconds: "по-малко от минута",
-  minute: "една минута",
-  minutes: "%d минути",
-  hour: "един час",
-  hours: "%d часа",
-  day: "един ден",
-  days: "%d дни",
-  month: "един месец",
-  months: "%d месеца",
-  year: "една година",
-  years: "%d години"
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: "преди",
+    prefixFromNow: "след",
+    suffixAgo: null,
+    suffixFromNow: null,
+    seconds: "по-малко от минута",
+    minute: "една минута",
+    minutes: "%d минути",
+    hour: "един час",
+    hours: "%d часа",
+    day: "един ден",
+    days: "%d дни",
+    month: "един месец",
+    months: "%d месеца",
+    year: "една година",
+    years: "%d години"
+  };
+}));

--- a/locales/jquery.timeago.bs.js
+++ b/locales/jquery.timeago.bs.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.bs.js
+++ b/locales/jquery.timeago.bs.js
@@ -1,8 +1,16 @@
 // Bosnian
-(function() {
-  var numpf;
-
-  numpf = function(n, f, s, t) {
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  function numpf(n, f, s, t) {
     var n10;
     n10 = n % 10;
     if (n10 === 1 && (n === 1 || n > 20)) {
@@ -13,8 +21,7 @@
       return t;
     }
   };
-
-  jQuery.timeago.settings.strings = {
+  $.timeago.settings.strings = {
     prefixAgo: "prije",
     prefixFromNow: "za",
     suffixAgo: null,
@@ -45,5 +52,4 @@
     },
     wordSeparator: " "
   };
-
-}).call(this);
+}));

--- a/locales/jquery.timeago.ca.js
+++ b/locales/jquery.timeago.ca.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.ca.js
+++ b/locales/jquery.timeago.ca.js
@@ -1,20 +1,32 @@
 // Catalan
-jQuery.timeago.settings.strings = {
-  prefixAgo: "fa",
-  prefixFromNow: "d'aquí",
-  suffixAgo: null,
-  suffixFromNow: null,
-  seconds: "menys d'un minut",
-  minute: "un minut",
-  minutes: "%d minuts",
-  hour: "una hora",
-  hours: "%d hores",
-  day: "un dia",
-  days: "%d dies",
-  month: "un mes",
-  months: "%d mesos",
-  year: "un any",
-  years: "%d anys",
-  wordSeparator: " ",
-  numbers: []
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: "fa",
+    prefixFromNow: "d'aquí",
+    suffixAgo: null,
+    suffixFromNow: null,
+    seconds: "menys d'un minut",
+    minute: "un minut",
+    minutes: "%d minuts",
+    hour: "una hora",
+    hours: "%d hores",
+    day: "un dia",
+    days: "%d dies",
+    month: "un mes",
+    months: "%d mesos",
+    year: "un any",
+    years: "%d anys",
+    wordSeparator: " ",
+    numbers: []
+  };
+}));

--- a/locales/jquery.timeago.cs.js
+++ b/locales/jquery.timeago.cs.js
@@ -1,24 +1,34 @@
 // Czech
-(function() {
-	function f(n, d, a) {
-		return a[d>=0 ? 0 : a.length===2 || n<5 ? 1 : 2];
-	}
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  function f(n, d, a) {
+    return a[d>=0 ? 0 : a.length===2 || n<5 ? 1 : 2];
+  }
 
-	jQuery.timeago.settings.strings = {
-		prefixAgo:     'před',
-		prefixFromNow: 'za',
-		suffixAgo:     null,
-		suffixFromNow: null,
-		seconds: function(n, d) {return f(n, d, ['méně než minutou', 'méně než minutu']);},
-		minute:  function(n, d) {return f(n, d, ['minutou', 'minutu']);},
-		minutes: function(n, d) {return f(n, d, ['%d minutami', '%d minuty', '%d minut']);},
-		hour:    function(n, d) {return f(n, d, ['hodinou', 'hodinu']);},
-		hours:   function(n, d) {return f(n, d, ['%d hodinami', '%d hodiny', '%d hodin']);},
-		day:     function(n, d) {return f(n, d, ['%d dnem', '%d den']);},
-		days:    function(n, d) {return f(n, d, ['%d dny', '%d dny', '%d dní']);},
-		month:   function(n, d) {return f(n, d, ['%d měsícem', '%d měsíc']);},
-		months:  function(n, d) {return f(n, d, ['%d měsíci', '%d měsíce', '%d měsíců']);},
-		year:    function(n, d) {return f(n, d, ['%d rokem', '%d rok']);},
-		years:   function(n, d) {return f(n, d, ['%d lety', '%d roky', '%d let']);}
-	};
-})();
+  $.timeago.settings.strings = {
+    prefixAgo:     'před',
+    prefixFromNow: 'za',
+    suffixAgo:     null,
+    suffixFromNow: null,
+    seconds: function(n, d) {return f(n, d, ['méně než minutou', 'méně než minutu']);},
+    minute:  function(n, d) {return f(n, d, ['minutou', 'minutu']);},
+    minutes: function(n, d) {return f(n, d, ['%d minutami', '%d minuty', '%d minut']);},
+    hour:    function(n, d) {return f(n, d, ['hodinou', 'hodinu']);},
+    hours:   function(n, d) {return f(n, d, ['%d hodinami', '%d hodiny', '%d hodin']);},
+    day:     function(n, d) {return f(n, d, ['%d dnem', '%d den']);},
+    days:    function(n, d) {return f(n, d, ['%d dny', '%d dny', '%d dní']);},
+    month:   function(n, d) {return f(n, d, ['%d měsícem', '%d měsíc']);},
+    months:  function(n, d) {return f(n, d, ['%d měsíci', '%d měsíce', '%d měsíců']);},
+    year:    function(n, d) {return f(n, d, ['%d rokem', '%d rok']);},
+    years:   function(n, d) {return f(n, d, ['%d lety', '%d roky', '%d let']);}
+  };
+}));

--- a/locales/jquery.timeago.cs.js
+++ b/locales/jquery.timeago.cs.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.cy.js
+++ b/locales/jquery.timeago.cy.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.cy.js
+++ b/locales/jquery.timeago.cy.js
@@ -1,20 +1,32 @@
 // Welsh
-jQuery.timeago.settings.strings = {
-  prefixAgo: null,
-  prefixFromNow: null,
-  suffixAgo: "yn ôl",
-  suffixFromNow: "o hyn",
-  seconds: "llai na munud",
-  minute: "am funud",
-  minutes: "%d munud",
-  hour: "tua awr",
-  hours: "am %d awr",
-  day: "y dydd",
-  days: "%d diwrnod",
-  month: "tua mis",
-  months: "%d mis",
-  year: "am y flwyddyn",
-  years: "%d blynedd",
-  wordSeparator: " ",
-  numbers: []
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: null,
+    suffixAgo: "yn ôl",
+    suffixFromNow: "o hyn",
+    seconds: "llai na munud",
+    minute: "am funud",
+    minutes: "%d munud",
+    hour: "tua awr",
+    hours: "am %d awr",
+    day: "y dydd",
+    days: "%d diwrnod",
+    month: "tua mis",
+    months: "%d mis",
+    year: "am y flwyddyn",
+    years: "%d blynedd",
+    wordSeparator: " ",
+    numbers: []
+  };
+}));

--- a/locales/jquery.timeago.da.js
+++ b/locales/jquery.timeago.da.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.da.js
+++ b/locales/jquery.timeago.da.js
@@ -1,18 +1,30 @@
 // Danish
-jQuery.timeago.settings.strings = {
-  prefixAgo: "for",
-  prefixFromNow: "om",
-  suffixAgo: "siden",
-  suffixFromNow: "",
-  seconds: "mindre end et minut",
-  minute: "ca. et minut",
-  minutes: "%d minutter",
-  hour: "ca. en time",
-  hours: "ca. %d timer",
-  day: "en dag",
-  days: "%d dage",
-  month: "ca. en måned",
-  months: "%d måneder",
-  year: "ca. et år",
-  years: "%d år"
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: "for",
+    prefixFromNow: "om",
+    suffixAgo: "siden",
+    suffixFromNow: "",
+    seconds: "mindre end et minut",
+    minute: "ca. et minut",
+    minutes: "%d minutter",
+    hour: "ca. en time",
+    hours: "ca. %d timer",
+    day: "en dag",
+    days: "%d dage",
+    month: "ca. en måned",
+    months: "%d måneder",
+    year: "ca. et år",
+    years: "%d år"
+  };
+}));

--- a/locales/jquery.timeago.de-short.js
+++ b/locales/jquery.timeago.de-short.js
@@ -1,20 +1,32 @@
 // German shortened
-jQuery.timeago.settings.strings = {
-  prefixAgo: null,
-  prefixFromNow: null,
-  suffixAgo: "",
-  suffixFromNow: "",
-  seconds: "s",
-  minute: "1m",
-  minutes: "%dm",
-  hour: "1h",
-  hours: "%dh",
-  day: "1T.",
-  days: "%dT.",
-  month: "1Mt.",
-  months: "%dMt.",
-  year: "1J.",
-  years: "%dJ.",
-  wordSeparator: " ",
-  numbers: []
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: null,
+    suffixAgo: "",
+    suffixFromNow: "",
+    seconds: "s",
+    minute: "1m",
+    minutes: "%dm",
+    hour: "1h",
+    hours: "%dh",
+    day: "1T.",
+    days: "%dT.",
+    month: "1Mt.",
+    months: "%dMt.",
+    year: "1J.",
+    years: "%dJ.",
+    wordSeparator: " ",
+    numbers: []
+  };
+}));

--- a/locales/jquery.timeago.de-short.js
+++ b/locales/jquery.timeago.de-short.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.de.js
+++ b/locales/jquery.timeago.de.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.de.js
+++ b/locales/jquery.timeago.de.js
@@ -1,18 +1,30 @@
 // German
-jQuery.timeago.settings.strings = {
-  prefixAgo: "vor",
-  prefixFromNow: "in",
-  suffixAgo: "",
-  suffixFromNow: "",
-  seconds: "wenigen Sekunden",
-  minute: "etwa einer Minute",
-  minutes: "%d Minuten",
-  hour: "etwa einer Stunde",
-  hours: "%d Stunden",
-  day: "etwa einem Tag",
-  days: "%d Tagen",
-  month: "etwa einem Monat",
-  months: "%d Monaten",
-  year: "etwa einem Jahr",
-  years: "%d Jahren"
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: "vor",
+    prefixFromNow: "in",
+    suffixAgo: "",
+    suffixFromNow: "",
+    seconds: "wenigen Sekunden",
+    minute: "etwa einer Minute",
+    minutes: "%d Minuten",
+    hour: "etwa einer Stunde",
+    hours: "%d Stunden",
+    day: "etwa einem Tag",
+    days: "%d Tagen",
+    month: "etwa einem Monat",
+    months: "%d Monaten",
+    year: "etwa einem Jahr",
+    years: "%d Jahren"
+  };
+}));

--- a/locales/jquery.timeago.dv.js
+++ b/locales/jquery.timeago.dv.js
@@ -1,22 +1,34 @@
-/** 
+/**
  * Dhivehi time in Thaana for timeago.js
  **/
-jQuery.timeago.settings.strings = {
-  prefixAgo: null,
-  prefixFromNow: null,
-  suffixAgo: "ކުރިން",
-  suffixFromNow: "ފަހުން",
-  seconds: "ސިކުންތުކޮޅެއް",
-  minute: "މިނިޓެއްވަރު",
-  minutes: "%d މިނިޓު",
-  hour: "ގަޑިއެއްވަރު",
-  hours: "ގާތްގަނޑަކަށް %d ގަޑިއިރު",
-  day: "އެއް ދުވަސް",
-  days: "މީގެ %d ދުވަސް",
-  month: "މަހެއްވަރު",
-  months: "މީގެ %d މަސް",
-  year: "އަހަރެއްވަރު",
-  years: "މީގެ %d އަހަރު",
-  wordSeparator: " ",
-  numbers: []
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: null,
+    suffixAgo: "ކުރިން",
+    suffixFromNow: "ފަހުން",
+    seconds: "ސިކުންތުކޮޅެއް",
+    minute: "މިނިޓެއްވަރު",
+    minutes: "%d މިނިޓު",
+    hour: "ގަޑިއެއްވަރު",
+    hours: "ގާތްގަނޑަކަށް %d ގަޑިއިރު",
+    day: "އެއް ދުވަސް",
+    days: "މީގެ %d ދުވަސް",
+    month: "މަހެއްވަރު",
+    months: "މީގެ %d މަސް",
+    year: "އަހަރެއްވަރު",
+    years: "މީގެ %d އަހަރު",
+    wordSeparator: " ",
+    numbers: []
+  };
+}));

--- a/locales/jquery.timeago.dv.js
+++ b/locales/jquery.timeago.dv.js
@@ -4,9 +4,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.el.js
+++ b/locales/jquery.timeago.el.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.el.js
+++ b/locales/jquery.timeago.el.js
@@ -1,18 +1,30 @@
 // Greek
-jQuery.timeago.settings.strings = {
-  prefixAgo: "πριν",
-  prefixFromNow: "σε",
-  suffixAgo: "",
-  suffixFromNow: "",
-  seconds: "λιγότερο από ένα λεπτό",
-  minute: "περίπου ένα λεπτό",
-  minutes: "%d λεπτά",
-  hour: "περίπου μία ώρα",
-  hours: "περίπου %d ώρες",
-  day: "μία μέρα",
-  days: "%d μέρες",
-  month: "περίπου ένα μήνα",
-  months: "%d μήνες",
-  year: "περίπου ένα χρόνο",
-  years: "%d χρόνια"
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: "πριν",
+    prefixFromNow: "σε",
+    suffixAgo: "",
+    suffixFromNow: "",
+    seconds: "λιγότερο από ένα λεπτό",
+    minute: "περίπου ένα λεπτό",
+    minutes: "%d λεπτά",
+    hour: "περίπου μία ώρα",
+    hours: "περίπου %d ώρες",
+    day: "μία μέρα",
+    days: "%d μέρες",
+    month: "περίπου ένα μήνα",
+    months: "%d μήνες",
+    year: "περίπου ένα χρόνο",
+    years: "%d χρόνια"
+  };
+}));

--- a/locales/jquery.timeago.en-short.js
+++ b/locales/jquery.timeago.en-short.js
@@ -1,20 +1,32 @@
 // English shortened
-jQuery.timeago.settings.strings = {
-  prefixAgo: null,
-  prefixFromNow: null,
-  suffixAgo: "",
-  suffixFromNow: "",
-  seconds: "1m",
-  minute: "1m",
-  minutes: "%dm",
-  hour: "1h",
-  hours: "%dh",
-  day: "1d",
-  days: "%dd",
-  month: "1mo",
-  months: "%dmo",
-  year: "1yr",
-  years: "%dyr",
-  wordSeparator: " ",
-  numbers: []
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: null,
+    suffixAgo: "",
+    suffixFromNow: "",
+    seconds: "1m",
+    minute: "1m",
+    minutes: "%dm",
+    hour: "1h",
+    hours: "%dh",
+    day: "1d",
+    days: "%dd",
+    month: "1mo",
+    months: "%dmo",
+    year: "1yr",
+    years: "%dyr",
+    wordSeparator: " ",
+    numbers: []
+  };
+}));

--- a/locales/jquery.timeago.en-short.js
+++ b/locales/jquery.timeago.en-short.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.en.js
+++ b/locales/jquery.timeago.en.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.en.js
+++ b/locales/jquery.timeago.en.js
@@ -1,20 +1,32 @@
 // English (Template)
-jQuery.timeago.settings.strings = {
-  prefixAgo: null,
-  prefixFromNow: null,
-  suffixAgo: "ago",
-  suffixFromNow: "from now",
-  seconds: "less than a minute",
-  minute: "about a minute",
-  minutes: "%d minutes",
-  hour: "about an hour",
-  hours: "about %d hours",
-  day: "a day",
-  days: "%d days",
-  month: "about a month",
-  months: "%d months",
-  year: "about a year",
-  years: "%d years",
-  wordSeparator: " ",
-  numbers: []
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: null,
+    suffixAgo: "ago",
+    suffixFromNow: "from now",
+    seconds: "less than a minute",
+    minute: "about a minute",
+    minutes: "%d minutes",
+    hour: "about an hour",
+    hours: "about %d hours",
+    day: "a day",
+    days: "%d days",
+    month: "about a month",
+    months: "%d months",
+    year: "about a year",
+    years: "%d years",
+    wordSeparator: " ",
+    numbers: []
+  };
+}));

--- a/locales/jquery.timeago.es-short.js
+++ b/locales/jquery.timeago.es-short.js
@@ -1,20 +1,32 @@
 // Spanish shortened
-jQuery.timeago.settings.strings = {
-  prefixAgo: null,
-  prefixFromNow: null,
-  suffixAgo: "",
-  suffixFromNow: "",
-  seconds: "1m",
-  minute: "1m",
-  minutes: "%dm",
-  hour: "1h",
-  hours: "%dh",
-  day: "1d",
-  days: "%dd",
-  month: "1me",
-  months: "%dme",
-  year: "1a",
-  years: "%da",
-  wordSeparator: " ",
-  numbers: []
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: null,
+    suffixAgo: "",
+    suffixFromNow: "",
+    seconds: "1m",
+    minute: "1m",
+    minutes: "%dm",
+    hour: "1h",
+    hours: "%dh",
+    day: "1d",
+    days: "%dd",
+    month: "1me",
+    months: "%dme",
+    year: "1a",
+    years: "%da",
+    wordSeparator: " ",
+    numbers: []
+  };
+}));

--- a/locales/jquery.timeago.es-short.js
+++ b/locales/jquery.timeago.es-short.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.es.js
+++ b/locales/jquery.timeago.es.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.es.js
+++ b/locales/jquery.timeago.es.js
@@ -1,18 +1,30 @@
 // Spanish
-jQuery.timeago.settings.strings = {
-   prefixAgo: "hace",
-   prefixFromNow: "dentro de",
-   suffixAgo: "",
-   suffixFromNow: "",
-   seconds: "menos de un minuto",
-   minute: "un minuto",
-   minutes: "unos %d minutos",
-   hour: "una hora",
-   hours: "%d horas",
-   day: "un día",
-   days: "%d días",
-   month: "un mes",
-   months: "%d meses",
-   year: "un año",
-   years: "%d años"
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: "hace",
+    prefixFromNow: "dentro de",
+    suffixAgo: "",
+    suffixFromNow: "",
+    seconds: "menos de un minuto",
+    minute: "un minuto",
+    minutes: "unos %d minutos",
+    hour: "una hora",
+    hours: "%d horas",
+    day: "un día",
+    days: "%d días",
+    month: "un mes",
+    months: "%d meses",
+    year: "un año",
+    years: "%d años"
+  };
+}));

--- a/locales/jquery.timeago.et.js
+++ b/locales/jquery.timeago.et.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.et.js
+++ b/locales/jquery.timeago.et.js
@@ -1,18 +1,30 @@
 // Estonian
-jQuery.timeago.settings.strings = {
-  prefixAgo: null,
-  prefixFromNow: null,
-  suffixAgo: "tagasi",
-  suffixFromNow: "pärast",
-  seconds: function(n, d) { return d < 0 ? "vähem kui minuti aja" : "vähem kui minut aega"; },
-  minute: function(n, d) { return d < 0 ? "umbes minuti aja" : "umbes minut aega"; },
-  minutes: function(n, d) { return d < 0 ? "%d minuti" : "%d minutit"; },
-  hour: function(n, d) { return d < 0 ? "umbes tunni aja" : "umbes tund aega"; },
-  hours: function(n, d) { return d < 0 ? "%d tunni" : "%d tundi"; },
-  day: function(n, d) { return d < 0 ? "umbes päeva" : "umbes päev"; },
-  days: "%d päeva",
-  month: function(n, d) { return d < 0 ? "umbes kuu aja" : "umbes kuu aega"; },
-  months: function(n, d) { return d < 0 ? "%d kuu" : "%d kuud"; },
-  year: function(n, d) { return d < 0 ? "umbes aasta aja" : "umbes aasta aega"; },
-  years: function(n, d) { return d < 0 ? "%d aasta" : "%d aastat"; }
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: null,
+    suffixAgo: "tagasi",
+    suffixFromNow: "pärast",
+    seconds: function(n, d) { return d < 0 ? "vähem kui minuti aja" : "vähem kui minut aega"; },
+    minute: function(n, d) { return d < 0 ? "umbes minuti aja" : "umbes minut aega"; },
+    minutes: function(n, d) { return d < 0 ? "%d minuti" : "%d minutit"; },
+    hour: function(n, d) { return d < 0 ? "umbes tunni aja" : "umbes tund aega"; },
+    hours: function(n, d) { return d < 0 ? "%d tunni" : "%d tundi"; },
+    day: function(n, d) { return d < 0 ? "umbes päeva" : "umbes päev"; },
+    days: "%d päeva",
+    month: function(n, d) { return d < 0 ? "umbes kuu aja" : "umbes kuu aega"; },
+    months: function(n, d) { return d < 0 ? "%d kuu" : "%d kuud"; },
+    year: function(n, d) { return d < 0 ? "umbes aasta aja" : "umbes aasta aega"; },
+    years: function(n, d) { return d < 0 ? "%d aasta" : "%d aastat"; }
+  };
+}));

--- a/locales/jquery.timeago.eu.js
+++ b/locales/jquery.timeago.eu.js
@@ -1,17 +1,29 @@
-jQuery.timeago.settings.strings = {
-   prefixAgo: "duela",
-   prefixFromNow: "hemendik",
-   suffixAgo: "",
-   suffixFromNow: "barru",
-   seconds: "minutu bat bainu gutxiago",
-   minute: "minutu bat",
-   minutes: "%d minutu inguru",
-   hour: "ordu bat",
-   hours: "%d ordu",
-   day: "egun bat",
-   days: "%d egun",
-   month: "hilabete bat",
-   months: "%d hilabete",
-   year: "urte bat",
-   years: "%d urte"
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: "duela",
+    prefixFromNow: "hemendik",
+    suffixAgo: "",
+    suffixFromNow: "barru",
+    seconds: "minutu bat bainu gutxiago",
+    minute: "minutu bat",
+    minutes: "%d minutu inguru",
+    hour: "ordu bat",
+    hours: "%d ordu",
+    day: "egun bat",
+    days: "%d egun",
+    month: "hilabete bat",
+    months: "%d hilabete",
+    year: "urte bat",
+    years: "%d urte"
+  };
+}));

--- a/locales/jquery.timeago.eu.js
+++ b/locales/jquery.timeago.eu.js
@@ -1,9 +1,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.fa-short.js
+++ b/locales/jquery.timeago.fa-short.js
@@ -1,20 +1,32 @@
 // persion shortened
-jQuery.timeago.settings.strings = {
-  prefixAgo: null,
-  prefixFromNow: null,
-  suffixAgo: "",
-  suffixFromNow: "",
-  seconds: "1دقیقه",
-  minute: "1دقیقه",
-  minutes: "%dدقیقه",
-  hour: "1ساعت",
-  hours: "%dساعت",
-  day: "1روز",
-  days: "%dروز",
-  month: "1ماه",
-  months: "%dماه",
-  year: "1سال",
-  years: "%dسال",
-  wordSeparator: " ",
-  numbers: ['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹']
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: null,
+    suffixAgo: "",
+    suffixFromNow: "",
+    seconds: "1دقیقه",
+    minute: "1دقیقه",
+    minutes: "%dدقیقه",
+    hour: "1ساعت",
+    hours: "%dساعت",
+    day: "1روز",
+    days: "%dروز",
+    month: "1ماه",
+    months: "%dماه",
+    year: "1سال",
+    years: "%dسال",
+    wordSeparator: " ",
+    numbers: ['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹']
+  };
+}));

--- a/locales/jquery.timeago.fa-short.js
+++ b/locales/jquery.timeago.fa-short.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.fa.js
+++ b/locales/jquery.timeago.fa.js
@@ -4,9 +4,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.fa.js
+++ b/locales/jquery.timeago.fa.js
@@ -1,22 +1,34 @@
 ﻿// Persian
 // Use DIR attribute for RTL text in Persian Language for ABBR tag .
 // By MB.seifollahi@gmail.com
-jQuery.timeago.settings.strings = {
-  prefixAgo: null,
-  prefixFromNow: null,
-  suffixAgo: "پیش",
-  suffixFromNow: "از حال",
-  seconds: "کمتر از یک دقیقه",
-  minute: "حدود یک دقیقه",
-  minutes: "%d دقیقه",
-  hour: "حدود یک ساعت",
-  hours: "حدود %d ساعت",
-  day: "یک روز",
-  days: "%d روز",
-  month: "حدود یک ماه",
-  months: "%d ماه",
-  year: "حدود یک سال",
-  years: "%d سال",
-  wordSeparator: " ",
-  numbers: ['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹']
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: null,
+    suffixAgo: "پیش",
+    suffixFromNow: "از حال",
+    seconds: "کمتر از یک دقیقه",
+    minute: "حدود یک دقیقه",
+    minutes: "%d دقیقه",
+    hour: "حدود یک ساعت",
+    hours: "حدود %d ساعت",
+    day: "یک روز",
+    days: "%d روز",
+    month: "حدود یک ماه",
+    months: "%d ماه",
+    year: "حدود یک سال",
+    years: "%d سال",
+    wordSeparator: " ",
+    numbers: ['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹']
+  };
+}));

--- a/locales/jquery.timeago.fi.js
+++ b/locales/jquery.timeago.fi.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.fi.js
+++ b/locales/jquery.timeago.fi.js
@@ -1,21 +1,33 @@
 // Finnish
-jQuery.timeago.settings.strings = {
-  prefixAgo: null,
-  prefixFromNow: null,
-  suffixAgo: "sitten",
-  suffixFromNow: "tulevaisuudessa",
-  seconds: "alle minuutti",
-  minute: "minuutti",
-  minutes: "%d minuuttia",
-  hour: "tunti",
-  hours: "%d tuntia",
-  day: "päivä",
-  days: "%d päivää",
-  month: "kuukausi",
-  months: "%d kuukautta",
-  year: "vuosi",
-  years: "%d vuotta"
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: null,
+    suffixAgo: "sitten",
+    suffixFromNow: "tulevaisuudessa",
+    seconds: "alle minuutti",
+    minute: "minuutti",
+    minutes: "%d minuuttia",
+    hour: "tunti",
+    hours: "%d tuntia",
+    day: "päivä",
+    days: "%d päivää",
+    month: "kuukausi",
+    months: "%d kuukautta",
+    year: "vuosi",
+    years: "%d vuotta"
+  };
+}));
 
 // The above is not a great localization because one would usually
 // write "2 days ago" in Finnish as "2 päivää sitten", however

--- a/locales/jquery.timeago.fr-short.js
+++ b/locales/jquery.timeago.fr-short.js
@@ -1,16 +1,28 @@
 // French shortened
-jQuery.timeago.settings.strings = {
-   prefixAgo: "il y a",
-   prefixFromNow: "d'ici",
-   seconds: "moins d'une minute",
-   minute: "une minute",
-   minutes: "%d minutes",
-   hour: "une heure",
-   hours: "%d heures",
-   day: "un jour",
-   days: "%d jours",
-   month: "un mois",
-   months: "%d mois",
-   year: "un an",
-   years: "%d ans"
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+   $.timeago.settings.strings = {
+      prefixAgo: "il y a",
+      prefixFromNow: "d'ici",
+      seconds: "moins d'une minute",
+      minute: "une minute",
+      minutes: "%d minutes",
+      hour: "une heure",
+      hours: "%d heures",
+      day: "un jour",
+      days: "%d jours",
+      month: "un mois",
+      months: "%d mois",
+      year: "un an",
+      years: "%d ans"
+   };
+}));

--- a/locales/jquery.timeago.fr-short.js
+++ b/locales/jquery.timeago.fr-short.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.fr.js
+++ b/locales/jquery.timeago.fr.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.fr.js
+++ b/locales/jquery.timeago.fr.js
@@ -1,17 +1,29 @@
 // French
-jQuery.timeago.settings.strings = {
-   // environ ~= about, it's optional
-   prefixAgo: "il y a",
-   prefixFromNow: "d'ici",
-   seconds: "moins d'une minute",
-   minute: "environ une minute",
-   minutes: "environ %d minutes",
-   hour: "environ une heure",
-   hours: "environ %d heures",
-   day: "environ un jour",
-   days: "environ %d jours",
-   month: "environ un mois",
-   months: "environ %d mois",
-   year: "un an",
-   years: "%d ans"
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    // environ ~= about, it's optional
+    prefixAgo: "il y a",
+    prefixFromNow: "d'ici",
+    seconds: "moins d'une minute",
+    minute: "environ une minute",
+    minutes: "environ %d minutes",
+    hour: "environ une heure",
+    hours: "environ %d heures",
+    day: "environ un jour",
+    days: "environ %d jours",
+    month: "environ un mois",
+    months: "environ %d mois",
+    year: "un an",
+    years: "%d ans"
+  };
+}));

--- a/locales/jquery.timeago.gl.js
+++ b/locales/jquery.timeago.gl.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.gl.js
+++ b/locales/jquery.timeago.gl.js
@@ -1,18 +1,30 @@
 // Galician
-jQuery.timeago.settings.strings = {
-   prefixAgo: "hai",
-   prefixFromNow: "dentro de",
-   suffixAgo: "",
-   suffixFromNow: "",
-   seconds: "menos dun minuto",
-   minute: "un minuto",
-   minutes: "uns %d minutos",
-   hour: "unha hora",
-   hours: "%d horas",
-   day: "un día",
-   days: "%d días",
-   month: "un mes",
-   months: "%d meses",
-   year: "un ano",
-   years: "%d anos"
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: "hai",
+    prefixFromNow: "dentro de",
+    suffixAgo: "",
+    suffixFromNow: "",
+    seconds: "menos dun minuto",
+    minute: "un minuto",
+    minutes: "uns %d minutos",
+    hour: "unha hora",
+    hours: "%d horas",
+    day: "un día",
+    days: "%d días",
+    month: "un mes",
+    months: "%d meses",
+    year: "un ano",
+    years: "%d anos"
+  };
+}));

--- a/locales/jquery.timeago.he.js
+++ b/locales/jquery.timeago.he.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.he.js
+++ b/locales/jquery.timeago.he.js
@@ -1,16 +1,28 @@
 // Hebrew
-jQuery.timeago.settings.strings = {
-  prefixAgo: "לפני",
-  prefixFromNow: "עוד",
-  seconds: "פחות מדקה",
-  minute: "דקה",
-  minutes: "%d דקות",
-  hour: "שעה",
-  hours: function(number){return (number===2) ? "שעתיים" : "%d שעות";},
-  day: "יום",
-  days: function(number){return (number===2) ? "יומיים" : "%d ימים";},
-  month: "חודש",
-  months: function(number){return (number===2) ? "חודשיים" : "%d חודשים";},
-  year: "שנה",
-  years: function(number){return (number===2) ? "שנתיים" : "%d שנים";}
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: "לפני",
+    prefixFromNow: "עוד",
+    seconds: "פחות מדקה",
+    minute: "דקה",
+    minutes: "%d דקות",
+    hour: "שעה",
+    hours: function(number){return (number===2) ? "שעתיים" : "%d שעות";},
+    day: "יום",
+    days: function(number){return (number===2) ? "יומיים" : "%d ימים";},
+    month: "חודש",
+    months: function(number){return (number===2) ? "חודשיים" : "%d חודשים";},
+    year: "שנה",
+    years: function(number){return (number===2) ? "שנתיים" : "%d שנים";}
+  };
+}));

--- a/locales/jquery.timeago.hr.js
+++ b/locales/jquery.timeago.hr.js
@@ -1,49 +1,55 @@
 // Croatian
-(function () {
-    var numpf;
-
-    numpf = function (n, f, s, t) {
-        var n10;
-        n10 = n % 10;
-        if (n10 === 1 && (n === 1 || n > 20)) {
-            return f;
-        } else if (n10 > 1 && n10 < 5 && (n > 20 || n < 10)) {
-            return s;
-        } else {
-            return t;
-        }
-    };
-
-    jQuery.timeago.settings.strings = {
-        prefixAgo: "prije",
-        prefixFromNow: "za",
-        suffixAgo: null,
-        suffixFromNow: null,
-        second: "sekundu",
-        seconds: function (value) {
-            return numpf(value, "%d sekundu", "%d sekunde", "%d sekundi");
-        },
-        minute: "oko minutu",
-        minutes: function (value) {
-            return numpf(value, "%d minutu", "%d minute", "%d minuta");
-        },
-        hour: "oko jedan sat",
-        hours: function (value) {
-            return numpf(value, "%d sat", "%d sata", "%d sati");
-        },
-        day: "jedan dan",
-        days: function (value) {
-            return numpf(value, "%d dan", "%d dana", "%d dana");
-        },
-        month: "mjesec dana",
-        months: function (value) {
-            return numpf(value, "%d mjesec", "%d mjeseca", "%d mjeseci");
-        },
-        year: "prije godinu dana",
-        years: function (value) {
-            return numpf(value, "%d godinu", "%d godine", "%d godina");
-        },
-        wordSeparator: " "
-    };
-
-}).call(this);
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  function numpf(n, f, s, t) {
+    var n10;
+    n10 = n % 10;
+    if (n10 === 1 && (n === 1 || n > 20)) {
+      return f;
+    } else if (n10 > 1 && n10 < 5 && (n > 20 || n < 10)) {
+      return s;
+    } else {
+      return t;
+    }
+  };
+  $.timeago.settings.strings = {
+    prefixAgo: "prije",
+    prefixFromNow: "za",
+    suffixAgo: null,
+    suffixFromNow: null,
+    second: "sekundu",
+    seconds: function (value) {
+      return numpf(value, "%d sekundu", "%d sekunde", "%d sekundi");
+    },
+    minute: "oko minutu",
+    minutes: function (value) {
+      return numpf(value, "%d minutu", "%d minute", "%d minuta");
+    },
+    hour: "oko jedan sat",
+    hours: function (value) {
+      return numpf(value, "%d sat", "%d sata", "%d sati");
+    },
+    day: "jedan dan",
+    days: function (value) {
+      return numpf(value, "%d dan", "%d dana", "%d dana");
+    },
+    month: "mjesec dana",
+    months: function (value) {
+      return numpf(value, "%d mjesec", "%d mjeseca", "%d mjeseci");
+    },
+    year: "prije godinu dana",
+    years: function (value) {
+      return numpf(value, "%d godinu", "%d godine", "%d godina");
+    },
+    wordSeparator: " "
+  };
+}));

--- a/locales/jquery.timeago.hr.js
+++ b/locales/jquery.timeago.hr.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.hu.js
+++ b/locales/jquery.timeago.hu.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.hu.js
+++ b/locales/jquery.timeago.hu.js
@@ -1,18 +1,30 @@
 // Hungarian
-jQuery.timeago.settings.strings = {
-  prefixAgo: null,
-  prefixFromNow: null,
-  suffixAgo: null,
-  suffixFromNow: null,
-  seconds: "kevesebb mint egy perce",
-  minute: "körülbelül egy perce",
-  minutes: "%d perce",
-  hour: "körülbelül egy órája",
-  hours: "körülbelül %d órája",
-  day: "körülbelül egy napja",
-  days: "%d napja",
-  month: "körülbelül egy hónapja",
-  months: "%d hónapja",
-  year: "körülbelül egy éve",
-  years: "%d éve"
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: null,
+    suffixAgo: null,
+    suffixFromNow: null,
+    seconds: "kevesebb mint egy perce",
+    minute: "körülbelül egy perce",
+    minutes: "%d perce",
+    hour: "körülbelül egy órája",
+    hours: "körülbelül %d órája",
+    day: "körülbelül egy napja",
+    days: "%d napja",
+    month: "körülbelül egy hónapja",
+    months: "%d hónapja",
+    year: "körülbelül egy éve",
+    years: "%d éve"
+  };
+}));

--- a/locales/jquery.timeago.hy.js
+++ b/locales/jquery.timeago.hy.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.hy.js
+++ b/locales/jquery.timeago.hy.js
@@ -1,18 +1,30 @@
 // Armenian
-jQuery.timeago.settings.strings = {
-  prefixAgo: null,
-  prefixFromNow: null,
-  suffixAgo: "առաջ",
-  suffixFromNow: "հետո",
-  seconds: "վայրկյաններ",
-  minute: "մեկ րոպե",
-  minutes: "%d րոպե",
-  hour: "մեկ ժամ",
-  hours: "%d ժամ",
-  day: "մեկ օր",
-  days: "%d օր",
-  month: "մեկ ամիս",
-  months: "%d ամիս",
-  year: "մեկ տարի",
-  years: "%d տարի"
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: null,
+    suffixAgo: "առաջ",
+    suffixFromNow: "հետո",
+    seconds: "վայրկյաններ",
+    minute: "մեկ րոպե",
+    minutes: "%d րոպե",
+    hour: "մեկ ժամ",
+    hours: "%d ժամ",
+    day: "մեկ օր",
+    days: "%d օր",
+    month: "մեկ ամիս",
+    months: "%d ամիս",
+    year: "մեկ տարի",
+    years: "%d տարի"
+  };
+}));

--- a/locales/jquery.timeago.id.js
+++ b/locales/jquery.timeago.id.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.id.js
+++ b/locales/jquery.timeago.id.js
@@ -1,18 +1,30 @@
 // Indonesian
-jQuery.timeago.settings.strings = {
-  prefixAgo: null,
-  prefixFromNow: null,
-  suffixAgo: "yang lalu",
-  suffixFromNow: "dari sekarang",
-  seconds: "kurang dari semenit",
-  minute: "sekitar satu menit",
-  minutes: "%d menit",
-  hour: "sekitar sejam",
-  hours: "sekitar %d jam",
-  day: "sehari",
-  days: "%d hari",
-  month: "sekitar sebulan",
-  months: "%d bulan",
-  year: "sekitar setahun",
-  years: "%d tahun"
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: null,
+    suffixAgo: "yang lalu",
+    suffixFromNow: "dari sekarang",
+    seconds: "kurang dari semenit",
+    minute: "sekitar satu menit",
+    minutes: "%d menit",
+    hour: "sekitar sejam",
+    hours: "sekitar %d jam",
+    day: "sehari",
+    days: "%d hari",
+    month: "sekitar sebulan",
+    months: "%d bulan",
+    year: "sekitar setahun",
+    years: "%d tahun"
+  };
+}));

--- a/locales/jquery.timeago.is.js
+++ b/locales/jquery.timeago.is.js
@@ -1,19 +1,31 @@
-jQuery.timeago.settings.strings = {
-  prefixAgo: "fyrir",
-  prefixFromNow: "eftir",
-  suffixAgo: "síðan",
-  suffixFromNow: null,
-  seconds: "minna en mínútu",
-  minute: "mínútu",
-  minutes: "%d mínútum",
-  hour: "klukkutíma",
-  hours: "um %d klukkutímum",
-  day: "degi",
-  days: "%d dögum",
-  month: "mánuði",
-  months: "%d mánuðum",
-  year: "ári",
-  years: "%d árum",
-  wordSeparator: " ",
-  numbers: []
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: "fyrir",
+    prefixFromNow: "eftir",
+    suffixAgo: "síðan",
+    suffixFromNow: null,
+    seconds: "minna en mínútu",
+    minute: "mínútu",
+    minutes: "%d mínútum",
+    hour: "klukkutíma",
+    hours: "um %d klukkutímum",
+    day: "degi",
+    days: "%d dögum",
+    month: "mánuði",
+    months: "%d mánuðum",
+    year: "ári",
+    years: "%d árum",
+    wordSeparator: " ",
+    numbers: []
+  };
+}));

--- a/locales/jquery.timeago.is.js
+++ b/locales/jquery.timeago.is.js
@@ -1,9 +1,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.it-short.js
+++ b/locales/jquery.timeago.it-short.js
@@ -1,20 +1,32 @@
 // Italian shortened
-jQuery.timeago.settings.strings = {
-  prefixAgo: null,
-  prefixFromNow: null,
-  suffixAgo: "",
-  suffixFromNow: "",
-  seconds: "1m",
-  minute: "1m",
-  minutes: "%dm",
-  hour: "1h",
-  hours: "%dh",
-  day: "1g",
-  days: "%dg",
-  month: "1me",
-  months: "%dme",
-  year: "1a",
-  years: "%da",
-  wordSeparator: " ",
-  numbers: []
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: null,
+    suffixAgo: "",
+    suffixFromNow: "",
+    seconds: "1m",
+    minute: "1m",
+    minutes: "%dm",
+    hour: "1h",
+    hours: "%dh",
+    day: "1g",
+    days: "%dg",
+    month: "1me",
+    months: "%dme",
+    year: "1a",
+    years: "%da",
+    wordSeparator: " ",
+    numbers: []
+  };
+}));

--- a/locales/jquery.timeago.it-short.js
+++ b/locales/jquery.timeago.it-short.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.it.js
+++ b/locales/jquery.timeago.it.js
@@ -1,16 +1,28 @@
 // Italian
-jQuery.timeago.settings.strings = {
-  suffixAgo: "fa",
-  suffixFromNow: "da ora",
-  seconds: "meno di un minuto",
-  minute: "circa un minuto",
-  minutes: "%d minuti",
-  hour: "circa un'ora",
-  hours: "circa %d ore",
-  day: "un giorno",
-  days: "%d giorni",
-  month: "circa un mese",
-  months: "%d mesi",
-  year: "circa un anno",
-  years: "%d anni"
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    suffixAgo: "fa",
+    suffixFromNow: "da ora",
+    seconds: "meno di un minuto",
+    minute: "circa un minuto",
+    minutes: "%d minuti",
+    hour: "circa un'ora",
+    hours: "circa %d ore",
+    day: "un giorno",
+    days: "%d giorni",
+    month: "circa un mese",
+    months: "%d mesi",
+    year: "circa un anno",
+    years: "%d anni"
+  };
+}));

--- a/locales/jquery.timeago.it.js
+++ b/locales/jquery.timeago.it.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.ja.js
+++ b/locales/jquery.timeago.ja.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.ja.js
+++ b/locales/jquery.timeago.ja.js
@@ -1,19 +1,31 @@
 // Japanese
-jQuery.timeago.settings.strings = {
-  prefixAgo: "",
-  prefixFromNow: "今から",
-  suffixAgo: "前",
-  suffixFromNow: "後",
-  seconds: "1 分未満",
-  minute: "約 1 分",
-  minutes: "%d 分",
-  hour: "約 1 時間",
-  hours: "約 %d 時間",
-  day: "約 1 日",
-  days: "約 %d 日",
-  month: "約 1 ヶ月",
-  months: "約 %d ヶ月",
-  year: "約 1 年",
-  years: "約 %d 年",
-  wordSeparator: ""
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: "",
+    prefixFromNow: "今から",
+    suffixAgo: "前",
+    suffixFromNow: "後",
+    seconds: "1 分未満",
+    minute: "約 1 分",
+    minutes: "%d 分",
+    hour: "約 1 時間",
+    hours: "約 %d 時間",
+    day: "約 1 日",
+    days: "約 %d 日",
+    month: "約 1 ヶ月",
+    months: "約 %d ヶ月",
+    year: "約 1 年",
+    years: "約 %d 年",
+    wordSeparator: ""
+  };
+}));

--- a/locales/jquery.timeago.jv.js
+++ b/locales/jquery.timeago.jv.js
@@ -1,18 +1,30 @@
 // Javanesse (Boso Jowo)
-jQuery.timeago.settings.strings = {
-  prefixAgo: null,
-  prefixFromNow: null,
-  suffixAgo: "kepungkur",
-  suffixFromNow: "seko saiki",
-  seconds: "kurang seko sakmenit",
-  minute: "kurang luwih sakmenit",
-  minutes: "%d menit",
-  hour: "kurang luwih sakjam",
-  hours: "kurang luwih %d jam",
-  day: "sedina",
-  days: "%d dina",
-  month: "kurang luwih sewulan",
-  months: "%d wulan",
-  year: "kurang luwih setahun",
-  years: "%d tahun"
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: null,
+    suffixAgo: "kepungkur",
+    suffixFromNow: "seko saiki",
+    seconds: "kurang seko sakmenit",
+    minute: "kurang luwih sakmenit",
+    minutes: "%d menit",
+    hour: "kurang luwih sakjam",
+    hours: "kurang luwih %d jam",
+    day: "sedina",
+    days: "%d dina",
+    month: "kurang luwih sewulan",
+    months: "%d wulan",
+    year: "kurang luwih setahun",
+    years: "%d tahun"
+  };
+}));

--- a/locales/jquery.timeago.jv.js
+++ b/locales/jquery.timeago.jv.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.ko.js
+++ b/locales/jquery.timeago.ko.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.ko.js
+++ b/locales/jquery.timeago.ko.js
@@ -1,20 +1,32 @@
 // Korean
-jQuery.timeago.settings.strings = {
-  prefixAgo: null,
-  prefixFromNow: null,
-  suffixAgo: "전",
-  suffixFromNow: "후",
-  seconds: "1분",
-  minute: "약 1분",
-  minutes: "%d분",
-  hour: "약 1시간",
-  hours: "약 %d시간",
-  day: "하루",
-  days: "%d일",
-  month: "약 1개월",
-  months: "%d개월",
-  year: "약 1년",
-  years: "%d년",
-  wordSeparator: " ",
-  numbers: []
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: null,
+    suffixAgo: "전",
+    suffixFromNow: "후",
+    seconds: "1분",
+    minute: "약 1분",
+    minutes: "%d분",
+    hour: "약 1시간",
+    hours: "약 %d시간",
+    day: "하루",
+    days: "%d일",
+    month: "약 1개월",
+    months: "%d개월",
+    year: "약 1년",
+    years: "%d년",
+    wordSeparator: " ",
+    numbers: []
+  };
+}));

--- a/locales/jquery.timeago.ky.js
+++ b/locales/jquery.timeago.ky.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.ky.js
+++ b/locales/jquery.timeago.ky.js
@@ -1,5 +1,15 @@
 // Russian
-(function() {
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
   function numpf(n, f, s, t) {
     // f - 1, 21, 31, ...
     // s - 2-4, 22-24, 32-34 ...
@@ -14,7 +24,7 @@
     }
   }
 
-  jQuery.timeago.settings.strings = {
+  $.timeago.settings.strings = {
     prefixAgo: null,
     prefixFromNow: "через",
     suffixAgo: "мурун",
@@ -31,4 +41,4 @@
     year: "жыл",
     years: function(value) { return numpf(value, "%d жыл", "%d жыл", "%d жыл"); }
   };
-})();
+}));

--- a/locales/jquery.timeago.lt.js
+++ b/locales/jquery.timeago.lt.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.lt.js
+++ b/locales/jquery.timeago.lt.js
@@ -1,20 +1,32 @@
-//Lithuanian      
-jQuery.timeago.settings.strings = {
-  prefixAgo: "prieš",
-  prefixFromNow: null,
-  suffixAgo: null,
-  suffixFromNow: "nuo dabar",
-  seconds: "%d sek.",
-  minute: "min.",
-  minutes: "%d min.",
-  hour: "val.",
-  hours: "%d val.",
-  day: "1 d.",
-  days: "%d d.",
-  month: "mėn.",
-  months: "%d mėn.",
-  year: "metus",
-  years: "%d metus",
-  wordSeparator: " ",
-  numbers: []
-};
+//Lithuanian
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: "prieš",
+    prefixFromNow: null,
+    suffixAgo: null,
+    suffixFromNow: "nuo dabar",
+    seconds: "%d sek.",
+    minute: "min.",
+    minutes: "%d min.",
+    hour: "val.",
+    hours: "%d val.",
+    day: "1 d.",
+    days: "%d d.",
+    month: "mėn.",
+    months: "%d mėn.",
+    year: "metus",
+    years: "%d metus",
+    wordSeparator: " ",
+    numbers: []
+  };
+}));

--- a/locales/jquery.timeago.lv.js
+++ b/locales/jquery.timeago.lv.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.lv.js
+++ b/locales/jquery.timeago.lv.js
@@ -1,20 +1,32 @@
 //Latvian
-jQuery.timeago.settings.strings = {
-  prefixAgo: "pirms",
-  prefixFromNow: null,
-  suffixAgo: null,
-  suffixFromNow: "no šī brīža",
-  seconds: "%d sek.",
-  minute: "min.",
-  minutes: "%d min.",
-  hour: "st.",
-  hours: "%d st.",
-  day: "1 d.",
-  days: "%d d.",
-  month: "mēnesis.",
-  months: "%d mēnesis.",
-  year: "gads",
-  years: "%d gads",
-  wordSeparator: " ",
-  numbers: []
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: "pirms",
+    prefixFromNow: null,
+    suffixAgo: null,
+    suffixFromNow: "no šī brīža",
+    seconds: "%d sek.",
+    minute: "min.",
+    minutes: "%d min.",
+    hour: "st.",
+    hours: "%d st.",
+    day: "1 d.",
+    days: "%d d.",
+    month: "mēnesis.",
+    months: "%d mēnesis.",
+    year: "gads",
+    years: "%d gads",
+    wordSeparator: " ",
+    numbers: []
+  };
+}));

--- a/locales/jquery.timeago.mk.js
+++ b/locales/jquery.timeago.mk.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.mk.js
+++ b/locales/jquery.timeago.mk.js
@@ -1,6 +1,16 @@
 // Macedonian
-(function() {
- jQuery.timeago.settings.strings={
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+ $.timeago.settings.strings={
     prefixAgo: "пред",
     prefixFromNow: "за",
     suffixAgo: null,
@@ -17,4 +27,4 @@
     year: "%d година",
     years: "%d години"
  };
-})();
+}));

--- a/locales/jquery.timeago.nl.js
+++ b/locales/jquery.timeago.nl.js
@@ -1,20 +1,32 @@
 // Dutch
-jQuery.timeago.settings.strings = {
-  prefixAgo: null,
-  prefixFromNow: "over",
-  suffixAgo: "geleden",
-  suffixFromNow: null,
-  seconds: "minder dan een minuut",
-  minute: "ongeveer een minuut",
-  minutes: "%d minuten",
-  hour: "ongeveer een uur",
-  hours: "ongeveer %d uur",
-  day: "een dag",
-  days: "%d dagen",
-  month: "ongeveer een maand",
-  months: "%d maanden",
-  year: "ongeveer een jaar",
-  years: "%d jaar",
-  wordSeparator: " ",
-  numbers: []
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: "over",
+    suffixAgo: "geleden",
+    suffixFromNow: null,
+    seconds: "minder dan een minuut",
+    minute: "ongeveer een minuut",
+    minutes: "%d minuten",
+    hour: "ongeveer een uur",
+    hours: "ongeveer %d uur",
+    day: "een dag",
+    days: "%d dagen",
+    month: "ongeveer een maand",
+    months: "%d maanden",
+    year: "ongeveer een jaar",
+    years: "%d jaar",
+    wordSeparator: " ",
+    numbers: []
+  };
+}));

--- a/locales/jquery.timeago.nl.js
+++ b/locales/jquery.timeago.nl.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.no.js
+++ b/locales/jquery.timeago.no.js
@@ -1,18 +1,30 @@
 // Norwegian
-jQuery.timeago.settings.strings = {
-  prefixAgo: "for",
-  prefixFromNow: "om",
-  suffixAgo: "siden",
-  suffixFromNow: "",
-  seconds: "mindre enn et minutt",
-  minute: "ca. et minutt",
-  minutes: "%d minutter",
-  hour: "ca. en time",
-  hours: "ca. %d timer",
-  day: "en dag",
-  days: "%d dager",
-  month: "ca. en måned",
-  months: "%d måneder",
-  year: "ca. et år",
-  years: "%d år"
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: "for",
+    prefixFromNow: "om",
+    suffixAgo: "siden",
+    suffixFromNow: "",
+    seconds: "mindre enn et minutt",
+    minute: "ca. et minutt",
+    minutes: "%d minutter",
+    hour: "ca. en time",
+    hours: "ca. %d timer",
+    day: "en dag",
+    days: "%d dager",
+    month: "ca. en måned",
+    months: "%d måneder",
+    year: "ca. et år",
+    years: "%d år"
+  };
+}));

--- a/locales/jquery.timeago.no.js
+++ b/locales/jquery.timeago.no.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.pl.js
+++ b/locales/jquery.timeago.pl.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.pl.js
+++ b/locales/jquery.timeago.pl.js
@@ -1,5 +1,15 @@
 // Polish
-(function() {
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
   function numpf(n, s, t) {
     // s - 2-4, 22-24, 32-34 ...
     // t - 5-21, 25-31, ...
@@ -11,7 +21,7 @@
     }
   }
 
-  jQuery.timeago.settings.strings = {
+  $.timeago.settings.strings = {
     prefixAgo: null,
     prefixFromNow: "za",
     suffixAgo: "temu",
@@ -28,4 +38,4 @@
     year: "rok",
     years: function(value) { return numpf(value, "%d lata", "%d lat"); }
   };
-})();
+}));

--- a/locales/jquery.timeago.pt-br-short.js
+++ b/locales/jquery.timeago.pt-br-short.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.pt-br-short.js
+++ b/locales/jquery.timeago.pt-br-short.js
@@ -1,20 +1,32 @@
 // Portuguese Brasil shortened
-jQuery.timeago.settings.strings = {
-  prefixAgo: null,
-  prefixFromNow: null,
-  suffixAgo: "",
-  suffixFromNow: "",
-  seconds: "1m",
-  minute: "1m",
-  minutes: "%dm",
-  hour: "1h",
-  hours: "%dh",
-  day: "1d",
-  days: "%dd",
-  month: "1M",
-  months: "%dM",
-  year: "1a",
-  years: "%da",
-  wordSeparator: " ",
-  numbers: []
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: null,
+    suffixAgo: "",
+    suffixFromNow: "",
+    seconds: "1m",
+    minute: "1m",
+    minutes: "%dm",
+    hour: "1h",
+    hours: "%dh",
+    day: "1d",
+    days: "%dd",
+    month: "1M",
+    months: "%dM",
+    year: "1a",
+    years: "%da",
+    wordSeparator: " ",
+    numbers: []
+  };
+}));

--- a/locales/jquery.timeago.pt-br.js
+++ b/locales/jquery.timeago.pt-br.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.pt-br.js
+++ b/locales/jquery.timeago.pt-br.js
@@ -1,18 +1,30 @@
-// Brazilian Portuguese 
-jQuery.timeago.settings.strings = {
-   prefixAgo: "há",
-   prefixFromNow: "em",
-   suffixAgo: null,
-   suffixFromNow: null,
-   seconds: "alguns segundos",
-   minute: "um minuto",
-   minutes: "%d minutos",
-   hour: "uma hora",
-   hours: "%d horas",
-   day: "um dia",
-   days: "%d dias",
-   month: "um mês",
-   months: "%d meses",
-   year: "um ano",
-   years: "%d anos"
-};
+// Brazilian Portuguese
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: "há",
+    prefixFromNow: "em",
+    suffixAgo: null,
+    suffixFromNow: null,
+    seconds: "alguns segundos",
+    minute: "um minuto",
+    minutes: "%d minutos",
+    hour: "uma hora",
+    hours: "%d horas",
+    day: "um dia",
+    days: "%d dias",
+    month: "um mês",
+    months: "%d meses",
+    year: "um ano",
+    years: "%d anos"
+  };
+}));

--- a/locales/jquery.timeago.pt-short.js
+++ b/locales/jquery.timeago.pt-short.js
@@ -1,20 +1,32 @@
 // Portuguese shortened
-jQuery.timeago.settings.strings = {
-  prefixAgo: null,
-  prefixFromNow: null,
-  suffixAgo: "",
-  suffixFromNow: "",
-  seconds: "1m",
-  minute: "1m",
-  minutes: "%dm",
-  hour: "1h",
-  hours: "%dh",
-  day: "1d",
-  days: "%dd",
-  month: "1M",
-  months: "%dM",
-  year: "1a",
-  years: "%da",
-  wordSeparator: " ",
-  numbers: []
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: null,
+    suffixAgo: "",
+    suffixFromNow: "",
+    seconds: "1m",
+    minute: "1m",
+    minutes: "%dm",
+    hour: "1h",
+    hours: "%dh",
+    day: "1d",
+    days: "%dd",
+    month: "1M",
+    months: "%dM",
+    year: "1a",
+    years: "%da",
+    wordSeparator: " ",
+    numbers: []
+  };
+}));

--- a/locales/jquery.timeago.pt-short.js
+++ b/locales/jquery.timeago.pt-short.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.pt.js
+++ b/locales/jquery.timeago.pt.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.pt.js
+++ b/locales/jquery.timeago.pt.js
@@ -1,16 +1,28 @@
 // Portuguese
-jQuery.timeago.settings.strings = {
-   suffixAgo: "atrás",
-   suffixFromNow: "a partir de agora",
-   seconds: "menos de um minuto",
-   minute: "cerca de um minuto",
-   minutes: "%d minutos",
-   hour: "cerca de uma hora",
-   hours: "cerca de %d horas",
-   day: "um dia",
-   days: "%d dias",
-   month: "cerca de um mês",
-   months: "%d meses",
-   year: "cerca de um ano",
-   years: "%d anos"
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    suffixAgo: "atrás",
+    suffixFromNow: "a partir de agora",
+    seconds: "menos de um minuto",
+    minute: "cerca de um minuto",
+    minutes: "%d minutos",
+    hour: "cerca de uma hora",
+    hours: "cerca de %d horas",
+    day: "um dia",
+    days: "%d dias",
+    month: "cerca de um mês",
+    months: "%d meses",
+    year: "cerca de um ano",
+    years: "%d anos"
+  };
+}));

--- a/locales/jquery.timeago.ro.js
+++ b/locales/jquery.timeago.ro.js
@@ -1,18 +1,30 @@
 // Romanian
-jQuery.timeago.settings.strings = {
-  prefixAgo: "acum",
-  prefixFromNow: "in timp de",
-  suffixAgo: "",
-  suffixFromNow: "",
-  seconds: "mai putin de un minut",
-  minute: "un minut",
-  minutes: "%d minute",
-  hour: "o ora",
-  hours: "%d ore",
-  day: "o zi",
-  days: "%d zile",
-  month: "o luna",
-  months: "%d luni",
-  year: "un an",
-  years: "%d ani"
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: "acum",
+    prefixFromNow: "in timp de",
+    suffixAgo: "",
+    suffixFromNow: "",
+    seconds: "mai putin de un minut",
+    minute: "un minut",
+    minutes: "%d minute",
+    hour: "o ora",
+    hours: "%d ore",
+    day: "o zi",
+    days: "%d zile",
+    month: "o luna",
+    months: "%d luni",
+    year: "un an",
+    years: "%d ani"
+  };
+}));

--- a/locales/jquery.timeago.ro.js
+++ b/locales/jquery.timeago.ro.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.rs.js
+++ b/locales/jquery.timeago.rs.js
@@ -1,49 +1,56 @@
 // Serbian
-(function () {
-    var numpf;
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  function numpf(n, f, s, t) {
+    var n10;
+    n10 = n % 10;
+    if (n10 === 1 && (n === 1 || n > 20)) {
+      return f;
+    } else if (n10 > 1 && n10 < 5 && (n > 20 || n < 10)) {
+      return s;
+    } else {
+      return t;
+    }
+  };
 
-    numpf = function (n, f, s, t) {
-        var n10;
-        n10 = n % 10;
-        if (n10 === 1 && (n === 1 || n > 20)) {
-            return f;
-        } else if (n10 > 1 && n10 < 5 && (n > 20 || n < 10)) {
-            return s;
-        } else {
-            return t;
-        }
-    };
-
-    jQuery.timeago.settings.strings = {
-        prefixAgo: "pre",
-        prefixFromNow: "za",
-        suffixAgo: null,
-        suffixFromNow: null,
-        second: "sekund",
-        seconds: function (value) {
-            return numpf(value, "%d sekund", "%d sekunde", "%d sekundi");
-        },
-        minute: "oko minut",
-        minutes: function (value) {
-            return numpf(value, "%d minut", "%d minuta", "%d minuta");
-        },
-        hour: "oko jedan sat",
-        hours: function (value) {
-            return numpf(value, "%d sat", "%d sata", "%d sati");
-        },
-        day: "jedan dan",
-        days: function (value) {
-            return numpf(value, "%d dan", "%d dana", "%d dana");
-        },
-        month: "mesec dana",
-        months: function (value) {
-            return numpf(value, "%d mesec", "%d meseca", "%d meseci");
-        },
-        year: "godinu dana",
-        years: function (value) {
-            return numpf(value, "%d godinu", "%d godine", "%d godina");
-        },
-        wordSeparator: " "
-    };
-
-}).call(this);
+  $.timeago.settings.strings = {
+    prefixAgo: "pre",
+    prefixFromNow: "za",
+    suffixAgo: null,
+    suffixFromNow: null,
+    second: "sekund",
+    seconds: function (value) {
+      return numpf(value, "%d sekund", "%d sekunde", "%d sekundi");
+    },
+    minute: "oko minut",
+    minutes: function (value) {
+      return numpf(value, "%d minut", "%d minuta", "%d minuta");
+    },
+    hour: "oko jedan sat",
+    hours: function (value) {
+      return numpf(value, "%d sat", "%d sata", "%d sati");
+    },
+    day: "jedan dan",
+    days: function (value) {
+      return numpf(value, "%d dan", "%d dana", "%d dana");
+    },
+    month: "mesec dana",
+    months: function (value) {
+      return numpf(value, "%d mesec", "%d meseca", "%d meseci");
+    },
+    year: "godinu dana",
+    years: function (value) {
+      return numpf(value, "%d godinu", "%d godine", "%d godina");
+    },
+    wordSeparator: " "
+  };
+}));

--- a/locales/jquery.timeago.rs.js
+++ b/locales/jquery.timeago.rs.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.ru.js
+++ b/locales/jquery.timeago.ru.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.ru.js
+++ b/locales/jquery.timeago.ru.js
@@ -1,5 +1,15 @@
 // Russian
-(function() {
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
   function numpf(n, f, s, t) {
     // f - 1, 21, 31, ...
     // s - 2-4, 22-24, 32-34 ...
@@ -14,7 +24,7 @@
     }
   }
 
-  jQuery.timeago.settings.strings = {
+  $.timeago.settings.strings = {
     prefixAgo: null,
     prefixFromNow: "через",
     suffixAgo: "назад",
@@ -31,4 +41,4 @@
     year: "год",
     years: function(value) { return numpf(value, "%d год", "%d года", "%d лет"); }
   };
-})();
+}));

--- a/locales/jquery.timeago.rw.js
+++ b/locales/jquery.timeago.rw.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.rw.js
+++ b/locales/jquery.timeago.rw.js
@@ -1,20 +1,32 @@
 // Kinyarwanda
-jQuery.timeago.settings.strings = {
-  prefixAgo: "hashize",
-  prefixFromNow: "mu",
-  suffixAgo: null,
-  suffixFromNow: null,
-  seconds: "amasegonda macye",
-  minute: "umunota",
-  minutes: "iminota %d",
-  hour: "isaha",
-  hours: "amasaha %d",
-  day: "umunsi",
-  days: "iminsi %d",
-  month: "ukwezi",
-  months: "amezi %d",
-  year: "umwaka",
-  years: "imyaka %d",
-  wordSeparator: " ",
-  numbers: []
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: "hashize",
+    prefixFromNow: "mu",
+    suffixAgo: null,
+    suffixFromNow: null,
+    seconds: "amasegonda macye",
+    minute: "umunota",
+    minutes: "iminota %d",
+    hour: "isaha",
+    hours: "amasaha %d",
+    day: "umunsi",
+    days: "iminsi %d",
+    month: "ukwezi",
+    months: "amezi %d",
+    year: "umwaka",
+    years: "imyaka %d",
+    wordSeparator: " ",
+    numbers: []
+  };
+}));

--- a/locales/jquery.timeago.si.js
+++ b/locales/jquery.timeago.si.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.si.js
+++ b/locales/jquery.timeago.si.js
@@ -1,18 +1,30 @@
 // Sinhalese (SI)
-jQuery.timeago.settings.strings = {
-  prefixAgo: null,
-  prefixFromNow: null,
-  suffixAgo: "පෙර",
-  suffixFromNow: "පසුව",
-  seconds: "තත්පර කිහිපයකට",
-  minute: "මිනිත්තුවකට පමණ",
-  minutes: "මිනිත්තු %d කට",
-  hour: "පැයක් පමණ ",
-  hours: "පැය %d කට  පමණ",
-  day: "දවසක ට",
-  days: "දවස් %d කට ",
-  month: "මාසයක් පමණ",
-  months: "මාස %d කට",
-  year: "වසරක් පමණ",
-  years: "වසරක් %d කට පමණ"
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: null,
+    suffixAgo: "පෙර",
+    suffixFromNow: "පසුව",
+    seconds: "තත්පර කිහිපයකට",
+    minute: "මිනිත්තුවකට පමණ",
+    minutes: "මිනිත්තු %d කට",
+    hour: "පැයක් පමණ ",
+    hours: "පැය %d කට  පමණ",
+    day: "දවසක ට",
+    days: "දවස් %d කට ",
+    month: "මාසයක් පමණ",
+    months: "මාස %d කට",
+    year: "වසරක් පමණ",
+    years: "වසරක් %d කට පමණ"
+  };
+}));

--- a/locales/jquery.timeago.sk.js
+++ b/locales/jquery.timeago.sk.js
@@ -1,18 +1,30 @@
 // Slovak
-jQuery.timeago.settings.strings = {
-  prefixAgo: "pred",
-  prefixFromNow: null,
-  suffixAgo: null,
-  suffixFromNow: null,
-  seconds: "menej než minútou",
-  minute: "minútou",
-  minutes: "%d minútami",
-  hour: "hodinou",
-  hours: "%d hodinami",
-  day: "1 dňom",
-  days: "%d dňami",
-  month: "1 mesiacom",
-  months: "%d mesiacmi",
-  year: "1 rokom",
-  years: "%d rokmi"
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: "pred",
+    prefixFromNow: null,
+    suffixAgo: null,
+    suffixFromNow: null,
+    seconds: "menej než minútou",
+    minute: "minútou",
+    minutes: "%d minútami",
+    hour: "hodinou",
+    hours: "%d hodinami",
+    day: "1 dňom",
+    days: "%d dňami",
+    month: "1 mesiacom",
+    months: "%d mesiacmi",
+    year: "1 rokom",
+    years: "%d rokmi"
+  };
+}));

--- a/locales/jquery.timeago.sk.js
+++ b/locales/jquery.timeago.sk.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.sl.js
+++ b/locales/jquery.timeago.sl.js
@@ -1,40 +1,48 @@
 // Slovenian with support for dual
-(function () {
-    var numpf;
-    numpf = function (n, a) {
-        return a[n%100===1 ? 1 : n%100===2 ? 2 : n%100===3 || n%100===4 ? 3 : 0];
-    };
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  function numpf(n, a) {
+    return a[n%100===1 ? 1 : n%100===2 ? 2 : n%100===3 || n%100===4 ? 3 : 0];
+  };
 
-    jQuery.timeago.settings.strings = {
-        prefixAgo: null,
-        prefixFromNow: "čez",
-        suffixAgo: "nazaj",
-        suffixFromNow: null,
-        second: "sekundo",
-        seconds: function (value) {
-            return numpf(value, ["%d sekund", "%d sekundo", "%d sekundi", "%d sekunde"]);
-        },
-        minute: "minuto",
-        minutes: function (value) {
-            return numpf(value, ["%d minut", "%d minuto", "%d minuti", "%d minute"]);
-        },
-        hour: "eno uro",
-        hours: function (value) {
-            return numpf(value, ["%d ur", "%d uro", "%d uri", "%d ure"]);
-        },
-        day: "en dan",
-        days: function (value) {
-            return numpf(value, ["%d dni", "%d dan", "%d dneva", "%d dni"]);
-        },
-        month: "en mesec",
-        months: function (value) {
-            return numpf(value, ["%d mesecev", "%d mesec", "%d meseca", "%d mesece"]);
-        },
-        year: "eno leto",
-        years: function (value) {
-            return numpf(value, ["%d let", "%d leto", "%d leti", "%d leta"]);
-        },
-        wordSeparator: " "
-    };
-
-}).call(this);
+  $.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: "čez",
+    suffixAgo: "nazaj",
+    suffixFromNow: null,
+    second: "sekundo",
+    seconds: function (value) {
+      return numpf(value, ["%d sekund", "%d sekundo", "%d sekundi", "%d sekunde"]);
+    },
+    minute: "minuto",
+    minutes: function (value) {
+      return numpf(value, ["%d minut", "%d minuto", "%d minuti", "%d minute"]);
+    },
+    hour: "eno uro",
+    hours: function (value) {
+      return numpf(value, ["%d ur", "%d uro", "%d uri", "%d ure"]);
+    },
+    day: "en dan",
+    days: function (value) {
+      return numpf(value, ["%d dni", "%d dan", "%d dneva", "%d dni"]);
+    },
+    month: "en mesec",
+    months: function (value) {
+      return numpf(value, ["%d mesecev", "%d mesec", "%d meseca", "%d mesece"]);
+    },
+    year: "eno leto",
+    years: function (value) {
+      return numpf(value, ["%d let", "%d leto", "%d leti", "%d leta"]);
+    },
+    wordSeparator: " "
+  };
+}));

--- a/locales/jquery.timeago.sl.js
+++ b/locales/jquery.timeago.sl.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.sr.js
+++ b/locales/jquery.timeago.sr.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.sr.js
+++ b/locales/jquery.timeago.sr.js
@@ -1,49 +1,56 @@
 // Serbian
-(function () {
-    var numpf;
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  function numpf(n, f, s, t) {
+      var n10;
+      n10 = n % 10;
+      if (n10 === 1 && (n === 1 || n > 20)) {
+          return f;
+      } else if (n10 > 1 && n10 < 5 && (n > 20 || n < 10)) {
+          return s;
+      } else {
+          return t;
+      }
+  };
 
-    numpf = function (n, f, s, t) {
-        var n10;
-        n10 = n % 10;
-        if (n10 === 1 && (n === 1 || n > 20)) {
-            return f;
-        } else if (n10 > 1 && n10 < 5 && (n > 20 || n < 10)) {
-            return s;
-        } else {
-            return t;
-        }
-    };
-
-    jQuery.timeago.settings.strings = {
-        prefixAgo: "пре",
-        prefixFromNow: "за",
-        suffixAgo: null,
-        suffixFromNow: null,
-        second: "секунд",
-        seconds: function (value) {
-            return numpf(value, "%d секунд", "%d секунде", "%d секунди");
-        },
-        minute: "један минут",
-        minutes: function (value) {
-            return numpf(value, "%d минут", "%d минута", "%d минута");
-        },
-        hour: "један сат",
-        hours: function (value) {
-            return numpf(value, "%d сат", "%d сата", "%d сати");
-        },
-        day: "један дан",
-        days: function (value) {
-            return numpf(value, "%d дан", "%d дана", "%d дана");
-        },
-        month: "месец дана",
-        months: function (value) {
-            return numpf(value, "%d месец", "%d месеца", "%d месеци");
-        },
-        year: "годину дана",
-        years: function (value) {
-            return numpf(value, "%d годину", "%d године", "%d година");
-        },
-        wordSeparator: " "
-    };
-
-}).call(this);
+  $.timeago.settings.strings = {
+    prefixAgo: "пре",
+    prefixFromNow: "за",
+    suffixAgo: null,
+    suffixFromNow: null,
+    second: "секунд",
+    seconds: function (value) {
+      return numpf(value, "%d секунд", "%d секунде", "%d секунди");
+    },
+    minute: "један минут",
+    minutes: function (value) {
+      return numpf(value, "%d минут", "%d минута", "%d минута");
+    },
+    hour: "један сат",
+    hours: function (value) {
+      return numpf(value, "%d сат", "%d сата", "%d сати");
+    },
+    day: "један дан",
+    days: function (value) {
+      return numpf(value, "%d дан", "%d дана", "%d дана");
+    },
+    month: "месец дана",
+    months: function (value) {
+      return numpf(value, "%d месец", "%d месеца", "%d месеци");
+    },
+    year: "годину дана",
+    years: function (value) {
+      return numpf(value, "%d годину", "%d године", "%d година");
+    },
+    wordSeparator: " "
+  };
+}));

--- a/locales/jquery.timeago.sv.js
+++ b/locales/jquery.timeago.sv.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.sv.js
+++ b/locales/jquery.timeago.sv.js
@@ -1,18 +1,30 @@
 // Swedish
-jQuery.timeago.settings.strings = {
-  prefixAgo: "för",
-  prefixFromNow: "om",
-  suffixAgo: "sedan",
-  suffixFromNow: "",
-  seconds: "mindre än en minut",
-  minute: "ungefär en minut",
-  minutes: "%d minuter",
-  hour: "ungefär en timme",
-  hours: "ungefär %d timmar",
-  day: "en dag",
-  days: "%d dagar",
-  month: "ungefär en månad",
-  months: "%d månader",
-  year: "ungefär ett år",
-  years: "%d år"
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: "för",
+    prefixFromNow: "om",
+    suffixAgo: "sedan",
+    suffixFromNow: "",
+    seconds: "mindre än en minut",
+    minute: "ungefär en minut",
+    minutes: "%d minuter",
+    hour: "ungefär en timme",
+    hours: "ungefär %d timmar",
+    day: "en dag",
+    days: "%d dagar",
+    month: "ungefär en månad",
+    months: "%d månader",
+    year: "ungefär ett år",
+    years: "%d år"
+  };
+}));

--- a/locales/jquery.timeago.th.js
+++ b/locales/jquery.timeago.th.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.th.js
+++ b/locales/jquery.timeago.th.js
@@ -1,20 +1,32 @@
 // Thai
-jQuery.timeago.settings.strings = {
-  prefixAgo: null,
-  prefixFromNow: null,
-  suffixAgo: "ที่แล้ว",
-  suffixFromNow: "จากตอนนี้",
-  seconds: "น้อยกว่าหนึ่งนาที",
-  minute: "ประมาณหนึ่งนาที",
-  minutes: "%d นาที",
-  hour: "ประมาณหนึ่งชั่วโมง",
-  hours: "ประมาณ %d ชั่วโมง",
-  day: "หนึ่งวัน",
-  days: "%d วัน",
-  month: "ประมาณหนึ่งเดือน",
-  months: "%d เดือน",
-  year: "ประมาณหนึ่งปี",
-  years: "%d ปี",
-  wordSeparator: "",
-  numbers: []
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: null,
+    suffixAgo: "ที่แล้ว",
+    suffixFromNow: "จากตอนนี้",
+    seconds: "น้อยกว่าหนึ่งนาที",
+    minute: "ประมาณหนึ่งนาที",
+    minutes: "%d นาที",
+    hour: "ประมาณหนึ่งชั่วโมง",
+    hours: "ประมาณ %d ชั่วโมง",
+    day: "หนึ่งวัน",
+    days: "%d วัน",
+    month: "ประมาณหนึ่งเดือน",
+    months: "%d เดือน",
+    year: "ประมาณหนึ่งปี",
+    years: "%d ปี",
+    wordSeparator: "",
+    numbers: []
+  };
+}));

--- a/locales/jquery.timeago.tr-short.js
+++ b/locales/jquery.timeago.tr-short.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.tr-short.js
+++ b/locales/jquery.timeago.tr-short.js
@@ -1,20 +1,32 @@
 // Turkish shortened
-jQuery.timeago.settings.strings = {
-  prefixAgo: null,
-  prefixFromNow: null,
-  suffixAgo: "",
-  suffixFromNow: "",
-  seconds: "1sn",
-  minute: "1d",
-  minutes: "%dd",
-  hour: "1s",
-  hours: "%ds",
-  day: "1g",
-  days: "%dg",
-  month: "1ay",
-  months: "%day",
-  year: "1y",
-  years: "%dy",
-  wordSeparator: " ",
-  numbers: []
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: null,
+    suffixAgo: "",
+    suffixFromNow: "",
+    seconds: "1sn",
+    minute: "1d",
+    minutes: "%dd",
+    hour: "1s",
+    hours: "%ds",
+    day: "1g",
+    days: "%dg",
+    month: "1ay",
+    months: "%day",
+    year: "1y",
+    years: "%dy",
+    wordSeparator: " ",
+    numbers: []
+  };
+}));

--- a/locales/jquery.timeago.tr.js
+++ b/locales/jquery.timeago.tr.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.tr.js
+++ b/locales/jquery.timeago.tr.js
@@ -1,16 +1,28 @@
 // Turkish
-jQuery.timeago.settings.strings = {
-   suffixAgo: 'önce',
-   suffixFromNow: null,
-   seconds: '1 dakikadan',
-   minute: '1 dakika',
-   minutes: '%d dakika',
-   hour: '1 saat',
-   hours: '%d saat',
-   day: '1 gün',
-   days: '%d gün',
-   month: '1 ay',
-   months: '%d ay',
-   year: '1 yıl',
-   years: '%d yıl'
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    suffixAgo: 'önce',
+    suffixFromNow: null,
+    seconds: '1 dakikadan',
+    minute: '1 dakika',
+    minutes: '%d dakika',
+    hour: '1 saat',
+    hours: '%d saat',
+    day: '1 gün',
+    days: '%d gün',
+    month: '1 ay',
+    months: '%d ay',
+    year: '1 yıl',
+    years: '%d yıl'
+  };
+}));

--- a/locales/jquery.timeago.uk.js
+++ b/locales/jquery.timeago.uk.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.uk.js
+++ b/locales/jquery.timeago.uk.js
@@ -1,5 +1,15 @@
 // Ukrainian
-(function() {
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
   function numpf(n, f, s, t) {
     // f - 1, 21, 31, ...
     // s - 2-4, 22-24, 32-34 ...
@@ -14,7 +24,7 @@
     }
   }
 
-  jQuery.timeago.settings.strings = {
+  $.timeago.settings.strings = {
     prefixAgo: null,
     prefixFromNow: "через",
     suffixAgo: "тому",
@@ -31,4 +41,4 @@
     year: "рік",
     years: function(value) { return numpf(value, "%d рік", "%d роки", "%d років"); }
   };
-})();
+}));

--- a/locales/jquery.timeago.uz.js
+++ b/locales/jquery.timeago.uz.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.uz.js
+++ b/locales/jquery.timeago.uz.js
@@ -1,19 +1,31 @@
 //Uzbek
-jQuery.timeago.settings.strings = {
-  prefixAgo: null,
-  prefixFromNow: "keyin",
-  suffixAgo: "avval",
-  suffixFromNow: null,
-  seconds: "bir necha soniya",
-  minute: "1 daqiqa",
-  minutes: function(value) { return "%d daqiqa"; },
-  hour: "1 soat",
-  hours: function(value) { return "%d soat"; },
-  day: "1 kun",
-  days: function(value) { return "%d kun"; },
-  month: "1 oy",
-  months: function(value) { return "%d oy"; },
-  year: "1 yil",
-  years: function(value) { return "%d yil"; },
-  wordSeparator: " "
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: "keyin",
+    suffixAgo: "avval",
+    suffixFromNow: null,
+    seconds: "bir necha soniya",
+    minute: "1 daqiqa",
+    minutes: function(value) { return "%d daqiqa"; },
+    hour: "1 soat",
+    hours: function(value) { return "%d soat"; },
+    day: "1 kun",
+    days: function(value) { return "%d kun"; },
+    month: "1 oy",
+    months: function(value) { return "%d oy"; },
+    year: "1 yil",
+    years: function(value) { return "%d yil"; },
+    wordSeparator: " "
+  };
+}));

--- a/locales/jquery.timeago.vi.js
+++ b/locales/jquery.timeago.vi.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.vi.js
+++ b/locales/jquery.timeago.vi.js
@@ -1,20 +1,32 @@
 // Vietnamese
-jQuery.timeago.settings.strings = {
-  prefixAgo: 'cách đây',
-  prefixFromNow: null,
-  suffixAgo: null,
-  suffixFromNow: "trước",
-  seconds: "chưa đến một phút",
-  minute: "khoảng một phút",
-  minutes: "%d phút",
-  hour: "khoảng một tiếng",
-  hours: "khoảng %d tiếng",
-  day: "một ngày",
-  days: "%d ngày",
-  month: "khoảng một tháng",
-  months: "%d tháng",
-  year: "khoảng một năm",
-  years: "%d năm",
-  wordSeparator: " ",
-  numbers: []
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: 'cách đây',
+    prefixFromNow: null,
+    suffixAgo: null,
+    suffixFromNow: "trước",
+    seconds: "chưa đến một phút",
+    minute: "khoảng một phút",
+    minutes: "%d phút",
+    hour: "khoảng một tiếng",
+    hours: "khoảng %d tiếng",
+    day: "một ngày",
+    days: "%d ngày",
+    month: "khoảng một tháng",
+    months: "%d tháng",
+    year: "khoảng một năm",
+    years: "%d năm",
+    wordSeparator: " ",
+    numbers: []
+  };
+}));

--- a/locales/jquery.timeago.zh-CN.js
+++ b/locales/jquery.timeago.zh-CN.js
@@ -1,20 +1,32 @@
 // Simplified Chinese
-jQuery.timeago.settings.strings = {
-  prefixAgo: null,
-  prefixFromNow: "从现在开始",
-  suffixAgo: "之前",
-  suffixFromNow: null,
-  seconds: "不到1分钟",
-  minute: "大约1分钟",
-  minutes: "%d分钟",
-  hour: "大约1小时",
-  hours: "大约%d小时",
-  day: "1天",
-  days: "%d天",
-  month: "大约1个月",
-  months: "%d月",
-  year: "大约1年",
-  years: "%d年",
-  numbers: [],
-  wordSeparator: ""
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: "从现在开始",
+    suffixAgo: "之前",
+    suffixFromNow: null,
+    seconds: "不到1分钟",
+    minute: "大约1分钟",
+    minutes: "%d分钟",
+    hour: "大约1小时",
+    hours: "大约%d小时",
+    day: "1天",
+    days: "%d天",
+    month: "大约1个月",
+    months: "%d月",
+    year: "大约1年",
+    years: "%d年",
+    numbers: [],
+    wordSeparator: ""
+  };
+}));

--- a/locales/jquery.timeago.zh-CN.js
+++ b/locales/jquery.timeago.zh-CN.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.zh-TW.js
+++ b/locales/jquery.timeago.zh-TW.js
@@ -2,9 +2,9 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['jquery'], factory);
+    define(['jquery', 'jquery.timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery', 'jquery.timeago'));
   } else {
     // Browser globals
     factory(jQuery);

--- a/locales/jquery.timeago.zh-TW.js
+++ b/locales/jquery.timeago.zh-TW.js
@@ -1,20 +1,32 @@
 // Traditional Chinese, zh-tw
-jQuery.timeago.settings.strings = {
-  prefixAgo: null,
-  prefixFromNow: "從現在開始",
-  suffixAgo: "之前",
-  suffixFromNow: null,
-  seconds: "不到1分鐘",
-  minute: "大約1分鐘",
-  minutes: "%d分鐘",
-  hour: "大約1小時",
-  hours: "%d小時",
-  day: "大約1天",
-  days: "%d天",
-  month: "大約1個月",
-  months: "%d個月",
-  year: "大約1年",
-  years: "%d年",
-  numbers: [],
-  wordSeparator: ""
-};
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(['jquery'], factory);
+  } else if (typeof module === 'object' && typeof module.exports === 'object') {
+    factory(require('jquery'));
+  } else {
+    // Browser globals
+    factory(jQuery);
+  }
+}(function ($) {
+  $.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: "從現在開始",
+    suffixAgo: "之前",
+    suffixFromNow: null,
+    seconds: "不到1分鐘",
+    minute: "大約1分鐘",
+    minutes: "%d分鐘",
+    hour: "大約1小時",
+    hours: "%d小時",
+    day: "大約1天",
+    days: "%d天",
+    month: "大約1個月",
+    months: "%d個月",
+    year: "大約1年",
+    years: "%d年",
+    numbers: [],
+    wordSeparator: ""
+  };
+}));


### PR DESCRIPTION
This makes the locales files compatible with loading jQuery and jQuery.timeago via an AMD loader, such as [require.js](http://requirejs.org/). Note that it may be easier to review this pull request by adding `?w=1` to the URL on GitHub, since that will cause GitHub to not display lines in the diff that only change whitespace.

Also note that these files all declare dependencies on the "jquery" module and the "jquery.timeago" module. I'm not sure if "jquery.timeago" is the right name to use, or if I should use a different one.
