### PR TITLE
added "secondaryFuzzing" support, to allow customized post-processing

### DIFF
--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -65,6 +65,14 @@
         years: "%d years",
         wordSeparator: " ",
         numbers: []
+      },
+      /**
+       * Secondary Fuzzing routine for post-processing.
+       * Should take in the element in question, the originally intended TimeAgo text and the distanceMillis between
+       * now and the given date.
+       */
+      secondaryFuzzing: function(el, originalText, distanceMillis) {
+    	  return originalText;
       }
     },
 
@@ -193,7 +201,12 @@
 
     if (!isNaN(data.datetime)) {
       if ( $s.cutoff === 0 || Math.abs(distance(data.datetime)) < $s.cutoff) {
-        $(this).text(inWords(data.datetime));
+        if ($.timeago.settings.secondaryFuzzing) {
+          var datetime = data.datetime;
+          $(this).text($.timeago.settings.secondaryFuzzing(this, inWords(datetime), distance(datetime)));
+        } else {
+          $(this).text(inWords(data.datetime));
+        }
       } else {
         if ($(this).attr('title').length > 0) {
             $(this).text($(this).attr('title'));


### PR DESCRIPTION
A common problem we've encountered in our applications is that we sometimes need _less_ granularity in recent dates.

For example, a task assigned for today, noon, needs to be displayed as "Today" rather than "23 minutes from now", since most tasks are time-agnostic.

For our own purposes, I've added support for post-processing by supplying a function as a timeago setting:

`$.timeago.settings.secondaryFuzzing = function(element, intendedText, difference) {}`

Which then applies necessary post-processing based on things such as element class, difference etc.

I figured it might be a useful use-case for the original codebase.
