### PR TITLE
Multiple init over the same instance produces multiple concurrent `setInterval`

### DIFF
--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -140,6 +140,7 @@
   // functions are called with context of a single element
   var functions = {
     init: function() {
+      functions.dispose.call(this);
       var refresh_el = $.proxy(refresh, this);
       refresh_el();
       var $s = $t.settings;


### PR DESCRIPTION
Just consider a case when we call `$('.timeago').timeago().timeago();`. We will have two concurrent running `setInterval`.
Please consider this one-liner fix. I couldn't figure out what tests to implement for this. If you have ideas please hint me.

@rmm5t please review.