### PR TITLE
Add jquery-timeago dependency to UMD wrappers

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,9 +26,9 @@ task :umd, [:files] do |t, args|
       <<~HEREDOC
         (function (factory) {
           if (typeof define === 'function' && define.amd) {
-            define(['jquery'], factory);
+            define(['jquery', 'jquery-timeago'], factory);
           } else if (typeof module === 'object' && typeof module.exports === 'object') {
-            factory(require('jquery'));
+            factory(require('jquery'), require('jquery-timeago'));
           } else {
             factory(jQuery);
           }

--- a/locales/jquery.timeago.af.js
+++ b/locales/jquery.timeago.af.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.am.js
+++ b/locales/jquery.timeago.am.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.ar.js
+++ b/locales/jquery.timeago.ar.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.az-short.js
+++ b/locales/jquery.timeago.az-short.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.az.js
+++ b/locales/jquery.timeago.az.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.bg.js
+++ b/locales/jquery.timeago.bg.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.bs.js
+++ b/locales/jquery.timeago.bs.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.ca.js
+++ b/locales/jquery.timeago.ca.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.cs.js
+++ b/locales/jquery.timeago.cs.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.cy.js
+++ b/locales/jquery.timeago.cy.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.da.js
+++ b/locales/jquery.timeago.da.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.de-short.js
+++ b/locales/jquery.timeago.de-short.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.de.js
+++ b/locales/jquery.timeago.de.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.dv.js
+++ b/locales/jquery.timeago.dv.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.el.js
+++ b/locales/jquery.timeago.el.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.en-short.js
+++ b/locales/jquery.timeago.en-short.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.en.js
+++ b/locales/jquery.timeago.en.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.es-short.js
+++ b/locales/jquery.timeago.es-short.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.es.js
+++ b/locales/jquery.timeago.es.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.et.js
+++ b/locales/jquery.timeago.et.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.eu.js
+++ b/locales/jquery.timeago.eu.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.fa-short.js
+++ b/locales/jquery.timeago.fa-short.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.fa.js
+++ b/locales/jquery.timeago.fa.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.fi.js
+++ b/locales/jquery.timeago.fi.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.fr-short.js
+++ b/locales/jquery.timeago.fr-short.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.fr.js
+++ b/locales/jquery.timeago.fr.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.gl.js
+++ b/locales/jquery.timeago.gl.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.he.js
+++ b/locales/jquery.timeago.he.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.hr.js
+++ b/locales/jquery.timeago.hr.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.hu.js
+++ b/locales/jquery.timeago.hu.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.hy.js
+++ b/locales/jquery.timeago.hy.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.id.js
+++ b/locales/jquery.timeago.id.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.is.js
+++ b/locales/jquery.timeago.is.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.it-short.js
+++ b/locales/jquery.timeago.it-short.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.it.js
+++ b/locales/jquery.timeago.it.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.ja.js
+++ b/locales/jquery.timeago.ja.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.jv.js
+++ b/locales/jquery.timeago.jv.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.ko.js
+++ b/locales/jquery.timeago.ko.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.ky.js
+++ b/locales/jquery.timeago.ky.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.lt.js
+++ b/locales/jquery.timeago.lt.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.lv.js
+++ b/locales/jquery.timeago.lv.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.mk.js
+++ b/locales/jquery.timeago.mk.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.nl.js
+++ b/locales/jquery.timeago.nl.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.no.js
+++ b/locales/jquery.timeago.no.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.pl.js
+++ b/locales/jquery.timeago.pl.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.pt-br-short.js
+++ b/locales/jquery.timeago.pt-br-short.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.pt-br.js
+++ b/locales/jquery.timeago.pt-br.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.pt-short.js
+++ b/locales/jquery.timeago.pt-short.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.pt.js
+++ b/locales/jquery.timeago.pt.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.ro.js
+++ b/locales/jquery.timeago.ro.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.rs.js
+++ b/locales/jquery.timeago.rs.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.ru.js
+++ b/locales/jquery.timeago.ru.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.rw.js
+++ b/locales/jquery.timeago.rw.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.si.js
+++ b/locales/jquery.timeago.si.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.sk.js
+++ b/locales/jquery.timeago.sk.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.sl.js
+++ b/locales/jquery.timeago.sl.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.sq.js
+++ b/locales/jquery.timeago.sq.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.sr.js
+++ b/locales/jquery.timeago.sr.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.sv.js
+++ b/locales/jquery.timeago.sv.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.th.js
+++ b/locales/jquery.timeago.th.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.tr-short.js
+++ b/locales/jquery.timeago.tr-short.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.tr.js
+++ b/locales/jquery.timeago.tr.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.uk.js
+++ b/locales/jquery.timeago.uk.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.uz.js
+++ b/locales/jquery.timeago.uz.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.vi.js
+++ b/locales/jquery.timeago.vi.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.zh-CN.js
+++ b/locales/jquery.timeago.zh-CN.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }

--- a/locales/jquery.timeago.zh-TW.js
+++ b/locales/jquery.timeago.zh-TW.js
@@ -1,8 +1,8 @@
 (function (factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['jquery'], factory);
+    define(['jquery', 'jquery-timeago'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    factory(require('jquery'));
+    factory(require('jquery'), require('jquery-timeago'));
   } else {
     factory(jQuery);
   }


### PR DESCRIPTION
As per issue discussed in rmm5t/jquery-timeago#323, locales cannot be loaded using CommonJS or AMD loaders reliably, since the *jquery-timeago* isn't specified as a required dependency.

This pull request fixes all locales to ensure *jquery-timeago* is loaded before locale data is set.