### PR TITLE
Update jquery.timeago.vi.js

### DIFF
--- a/locales/jquery.timeago.vi.js
+++ b/locales/jquery.timeago.vi.js
@@ -11,8 +11,8 @@
   jQuery.timeago.settings.strings = {
     prefixAgo: 'cách đây',
     prefixFromNow: null,
-    suffixAgo: null,
-    suffixFromNow: "trước",
+    suffixAgo: "trước",
+    suffixFromNow: "kể từ bây giờ",
     seconds: "chưa đến một phút",
     minute: "khoảng một phút",
     minutes: "%d phút",


### PR DESCRIPTION
"from now" isn't "trước" and it feels empty without an ago suffix for the language.