### PR TITLE
Improve italian translation

### DIFF
--- a/locales/jquery.timeago.it.js
+++ b/locales/jquery.timeago.it.js
@@ -9,8 +9,10 @@
 }(function (jQuery) {
   // Italian
   jQuery.timeago.settings.strings = {
+    prefixAgo: null,
+    prefixFromNow: "fra",
     suffixAgo: "fa",
-    suffixFromNow: "da ora",
+    suffixFromNow: null,
     seconds: "meno di un minuto",
     minute: "circa un minuto",
     minutes: "%d minuti",


### PR DESCRIPTION
"da ora" is a very literal translation of "from now", and not much used in this sense - strictly speaking, it could even mean "ago".