### PR TITLE
remove invalid character from fa locale that result in parsing error in IE

### DIFF
--- a/locales/jquery.timeago.fa.js
+++ b/locales/jquery.timeago.fa.js
@@ -7,7 +7,7 @@
     factory(jQuery);
   }
 }(function (jQuery) {
-  ﻿// Persian
+  // Persian
   // Use DIR attribute for RTL text in Persian Language for ABBR tag .
   // By MB.seifollahi@gmail.com
   jQuery.timeago.settings.strings = {


### PR DESCRIPTION
Hi,

I encountered a problem when loading the fa locale.

There is an invalid character in front of the "//" in the fa locale that results in a parsing error in IE:
`SCRIPT1014: Invalid character jquery.timeago.fa.js (10,4)`

Other browsers are not affected as far as I can tell.

Github is not showing the character on the web so here is a screenshot of the diff:
<img width="511" alt="jquery-timeago-fa-locale-fix-diff" src="https://user-images.githubusercontent.com/231497/52094886-199ac500-25c1-11e9-9f2e-9e3b083a542f.png">