### PR TITLE
docs: Fix simple typo, persion -> persian

### DIFF
--- a/locales/jquery.timeago.fa-short.js
+++ b/locales/jquery.timeago.fa-short.js
@@ -7,7 +7,7 @@
     factory(jQuery);
   }
 }(function (jQuery) {
-  // persion shortened
+  // persian shortened
   jQuery.timeago.settings.strings = {
     prefixAgo: null,
     prefixFromNow: null,


### PR DESCRIPTION
There is a small typo in locales/jquery.timeago.fa-short.js.

Should read `persian` rather than `persion`.

