### PR TITLE
remove wordSeparator so space is used like turkish

### DIFF
--- a/locales/jquery.timeago.az.js
+++ b/locales/jquery.timeago.az.js
@@ -24,7 +24,6 @@
     months: '%d ay',
     year: '1 il',
     years: '%d il',
-    wordSeparator: '',
     numbers: []
   };
 }));


### PR DESCRIPTION
correct spelling is `3 gün əvvəl`

![image](https://github.com/user-attachments/assets/f79beb9e-820f-4966-914c-ca721e81f2e5)
